### PR TITLE
fix: handle labels: null in job/workflow template actions

### DIFF
--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -90,7 +90,7 @@ class RunJobTemplate:
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
         )
-        job_labels = list(self.action_args.get("labels", []))
+        job_labels = list(self.action_args.get("labels") or [])
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -89,7 +89,7 @@ class RunWorkflowTemplate:
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
         )
-        job_labels = list(self.action_args.get("labels", []))
+        job_labels = list(self.action_args.get("labels") or [])
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -296,3 +296,55 @@ async def test_run_job_template_retries():
                 drools_mock.assert_called_once()
 
             _validate(queue, True)
+
+
+@pytest.mark.asyncio
+async def test_run_job_template_with_null_labels():
+    """Verify labels: null in rulebook YAML does not raise TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": 0,
+        "retry": True,
+        "delay": 0,
+        "set_facts": True,
+        "labels": None,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_job_template."
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_job_template.lang.assert_fact"
+            ):
+                await RunJobTemplate(metadata, control, **action_args)()
+
+        _validate(queue, True)

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -308,3 +308,58 @@ async def test_run_workflow_template_url(job_id):
             assert ((not job_id) and (action["url"] == "")) or (
                 job_id and (action["url"] != "")
             )
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_template_with_null_labels():
+    """Verify labels: null in rulebook YAML does not raise TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": 0,
+        "retry": True,
+        "delay": 0,
+        "set_facts": True,
+        "labels": None,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_workflow_template."
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_workflow_template."
+                "lang.assert_fact"
+            ):
+                await RunWorkflowTemplate(
+                    metadata, control, **action_args
+                )()
+
+        _validate(queue, True)


### PR DESCRIPTION
## Problem

In the `event_persistence` branch, both `run_job_template.py` and `run_workflow_template.py` construct `job_labels` like this:

```python
job_labels = list(self.action_args.get("labels", []))
```

When a rulebook specifies `labels: null` (valid YAML — `null`, `~`, or empty value all parse to `None` in Python), `action_args.get("labels", [])` returns `None` because the key **exists** with value `None` — the default `[]` is only used when the key is absent. Then `list(None)` raises:

```
TypeError: 'NoneType' object is not iterable
```

This crashes the action — the job never launches and rule processing halts.

### Prior behavior (main branch)

On `main`, labels were passed straight through as `None`:
```python
self.action_args.get("labels"),  # None passed to runner, handled downstream
```
The downstream `_get_label_ids_from_names` method treats `None` and `[]` identically (both are falsy, so the `if labels:` gate skips user labels). No crash occurred.

### When it shows up in production

Any user with `labels: null` (or `labels: ~`) in their rulebook YAML hits a `TypeError` crash on every rule firing. This is a regression introduced by the persistence changes.

## Solution

Replace `get("labels", [])` with `get("labels") or []` in both files:

```python
job_labels = list(self.action_args.get("labels") or [])
```

The `or []` coerces `None` to `[]` before the `list()` copy, which is consistent with how the downstream controller API treats them — [AWX explicitly documents](https://github.com/ansible/awx/blob/devel/awx/main/models/jobs.py) that *"Many to manys can't distinguish between None and []. We assume [] is none."*

## Files changed

- `ansible_rulebook/action/run_job_template.py` — line 93
- `ansible_rulebook/action/run_workflow_template.py` — line 92