### PR TITLE
fix: handle labels: null in job/workflow template actions

### DIFF
--- a/ansible_rulebook/action/debug.py
+++ b/ansible_rulebook/action/debug.py
@@ -66,6 +66,7 @@ class Debug:
                 raise
         else:
             args = asdict(self.helper.metadata)
+            args.pop("persistent_info", None)
             project_data_file = self.helper.control.project_data_file
             args.update(
                 {

--- a/ansible_rulebook/action/helper.py
+++ b/ansible_rulebook/action/helper.py
@@ -12,20 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 import uuid
-from typing import Dict
+from typing import Dict, Optional
 
 from ansible_rulebook.conf import settings
 from ansible_rulebook.event_filter.insert_meta_info import main as insert_meta
+from ansible_rulebook.job_template_runner import job_template_runner
+from ansible_rulebook.persistence import update_action_info
 from ansible_rulebook.util import run_at
 
 from .control import Control
 from .metadata import Metadata
 
+logger = logging.getLogger(__name__)
+
 KEY_EDA_VARS = "ansible_eda"
 INTERNAL_ACTION_STATUS = "successful"
 FAILED_STATUS = "failed"
 SUCCESSFUL_STATUS = "successful"
+STARTED_STATUS = "started"
 
 
 class Helper:
@@ -155,3 +161,108 @@ class Helper:
 
         extra_vars[KEY_EDA_VARS] = eda_vars
         return extra_vars
+
+    def update_action_state(self, info: dict) -> None:
+        """Update action state in the persistence store.
+
+        This method persists action execution state to the database when
+        persistence is enabled, allowing actions to be tracked and recovered
+        across rulebook restarts or failover scenarios.
+
+        Args:
+            info: Dictionary containing action state information to persist
+
+        Returns:
+            None
+        """
+        if self.metadata.persistent_info:
+            update_action_info(
+                self.metadata.rule_set,
+                self.metadata.persistent_info.matching_uuid,
+                self.metadata.persistent_info.action_index,
+                info,
+            )
+
+    def get_event_uuid_label(self) -> str:
+        """Extract event UUID and format it as a label.
+
+        This method retrieves the UUID from the matching event(s) and
+        formats it as a label string that can be used to tag jobs in the
+        controller. This enables correlation between jobs and the events
+        that triggered them.
+
+        Returns:
+            str: Formatted label string in the format "eda-event-uuid-{uuid}"
+
+        Raises:
+            ValueError: If the event structure is invalid (no 'm' or 'm_0' key)
+        """
+        events = self.get_events()
+        if "m" in events:
+            try:
+                event_uuid = events["m"]["meta"]["uuid"]
+            except KeyError:
+                raise ValueError(
+                    "Event missing meta.uuid in single event match"
+                )
+        elif "m_0" in events:
+            try:
+                event_uuid = events["m_0"]["meta"]["uuid"]
+            except KeyError:
+                raise ValueError(
+                    "Event missing meta.uuid in multi event match"
+                )
+        else:
+            raise ValueError("Invalid event type")
+
+        return f"eda-event-uuid-{event_uuid}"
+
+    async def get_old_job_url(
+        self,
+        name: str,
+        organization: str,
+        obj_type: str,
+        add_event_uuid_label: bool,
+    ) -> Optional[str]:
+        """Retrieve job URL from a previous execution for resumption.
+
+        In persistence/HA mode, this method attempts to retrieve the URL of
+        a job that was launched in a previous execution but may not have
+        completed due to a process restart or failover. This enables the
+        action to resume monitoring the existing job rather than launching
+        a duplicate.
+
+        Args:
+            name: Name of the job or workflow template
+            organization: Organization name containing the template
+            obj_type: Type of template ("job_template" or
+                "workflow_template")
+            add_event_uuid_label: If True, attempt to find job by event
+                UUID label when job_url is not directly available
+
+        Returns:
+            Optional[str]: The job URL if found from a previous run,
+                None otherwise
+        """
+        if not self.metadata.persistent_info:
+            return None
+
+        a_priori = self.metadata.persistent_info.a_priori
+        if not a_priori:
+            return None
+        if a_priori.get("job_url"):
+            job_url = a_priori["job_url"]
+            logger.debug("Will monitor job %s from earlier run", job_url)
+            return job_url
+        if a_priori.get("status") == STARTED_STATUS and add_event_uuid_label:
+            logger.debug("Fetching job url using event label from earlier run")
+            job_url = await job_template_runner.get_job_url_from_label(
+                name,
+                organization,
+                obj_type,
+                self.get_event_uuid_label(),
+            )
+            logger.debug("Will monitor job %s from earlier run", job_url)
+            return job_url
+
+        return None

--- a/ansible_rulebook/action/metadata.py
+++ b/ansible_rulebook/action/metadata.py
@@ -13,6 +13,37 @@
 #  limitations under the License.
 
 from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ActionPersistence:
+    """ActionPersistence class stores the persistence information
+    which is used to ensure that an action has been persisted and
+    not lost during outages in execution
+
+    Attributes
+    ----------
+    matching_uuid: str
+        The matching UUID used when in HA mode
+    action_index: int
+        The action index
+    last_action: bool
+        If this is a last action for the rule
+    a_priori: dict
+        Previous information for this action
+    """
+
+    __slots__ = [
+        "matching_uuid",
+        "action_index",
+        "last_action",
+        "a_priori",
+    ]
+    matching_uuid: Optional[str]
+    action_index: int
+    last_action: bool
+    a_priori: Optional[dict]
 
 
 @dataclass(frozen=True)
@@ -32,17 +63,12 @@ class Metadata:
         Rule set uuid
     rule_run_at: str
         ISO 8601 date/time when the rule was triggered
+    persistent_info: Optional[ActionPersistence]
     """
 
-    __slots__ = [
-        "rule",
-        "rule_uuid",
-        "rule_set",
-        "rule_set_uuid",
-        "rule_run_at",
-    ]
     rule: str
     rule_uuid: str
     rule_set: str
     rule_set_uuid: str
     rule_run_at: str
+    persistent_info: Optional[ActionPersistence] = None

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -25,7 +25,10 @@ from ansible_rulebook.exception import (
     ControllerApiException,
     JobTemplateNotFoundException,
 )
-from ansible_rulebook.job_template_runner import job_template_runner
+from ansible_rulebook.job_template_runner import (
+    JOB_TEMPLATE_TYPE,
+    job_template_runner,
+)
 from ansible_rulebook.util import process_controller_host_limit, run_at
 
 from .control import Control
@@ -84,8 +87,20 @@ class RunJobTemplate:
         if self.action_args.get("retry", False):
             retries = max(self.action_args.get("retries", 0), 1)
         delay = self.action_args.get("delay", 0)
+        add_event_uuid_label = self.action_args.get(
+            "add_event_uuid_label", False
+        )
+        job_labels = list(self.action_args.get("labels", []))
+        if add_event_uuid_label:
+            job_labels.append(self.helper.get_event_uuid_label())
 
         try:
+            job_url = await self.helper.get_old_job_url(
+                self.name,
+                self.organization,
+                JOB_TEMPLATE_TYPE,
+                add_event_uuid_label,
+            )
             for i in range(retries + 1):
                 if i > 0:
                     if delay > 0:
@@ -95,14 +110,27 @@ class RunJobTemplate:
                         i,
                         retries,
                     )
-                controller_job = await job_template_runner.run_job_template(
-                    self.name,
-                    self.organization,
-                    self.job_args,
-                    self.action_args.get("labels"),
-                )
+                # Launch the job and get URL immediately
+                if not job_url:
+                    job_url = await job_template_runner.launch_job_template(
+                        self.name,
+                        self.organization,
+                        self.job_args,
+                        job_labels,
+                    )
+                    logger.info(f"Job Launched, url: {job_url}")
+                    self.helper.update_action_state({"job_url": job_url})
+
+                # Monitor the job until completion
+                controller_job = await job_template_runner.monitor_job(job_url)
+
                 if controller_job["status"] != "failed":
                     break
+
+                # Reset job_url to launch a new job on retry
+                job_url = None
+                self.helper.update_action_state({"job_url": None})
+
         except (ControllerApiException, JobTemplateNotFoundException) as ex:
             logger.error(ex)
             controller_job = {}

--- a/ansible_rulebook/action/run_job_template.py
+++ b/ansible_rulebook/action/run_job_template.py
@@ -90,7 +90,7 @@ class RunJobTemplate:
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
         )
-        job_labels = list(self.action_args.get("labels", []))
+        job_labels = list(self.action_args.get("labels") or [])
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -25,7 +25,10 @@ from ansible_rulebook.exception import (
     ControllerApiException,
     WorkflowJobTemplateNotFoundException,
 )
-from ansible_rulebook.job_template_runner import job_template_runner
+from ansible_rulebook.job_template_runner import (
+    WORKFLOW_TEMPLATE_TYPE,
+    job_template_runner,
+)
 from ansible_rulebook.util import process_controller_host_limit, run_at
 
 from .control import Control
@@ -83,8 +86,20 @@ class RunWorkflowTemplate:
         if self.action_args.get("retry", False):
             retries = max(self.action_args.get("retries", 0), 1)
         delay = self.action_args.get("delay", 0)
+        add_event_uuid_label = self.action_args.get(
+            "add_event_uuid_label", False
+        )
+        job_labels = list(self.action_args.get("labels", []))
+        if add_event_uuid_label:
+            job_labels.append(self.helper.get_event_uuid_label())
 
         try:
+            job_url = await self.helper.get_old_job_url(
+                self.name,
+                self.organization,
+                WORKFLOW_TEMPLATE_TYPE,
+                add_event_uuid_label,
+            )
             for i in range(retries + 1):
                 if i > 0:
                     if delay > 0:
@@ -95,16 +110,27 @@ class RunWorkflowTemplate:
                         i,
                         retries,
                     )
-                controller_job = (
-                    await job_template_runner.run_workflow_job_template(
-                        self.name,
-                        self.organization,
-                        self.job_args,
-                        self.action_args.get("labels"),
+                # Launch the workflow and get URL immediately
+                if job_url is None:
+                    job_url = (
+                        await job_template_runner.launch_workflow_job_template(
+                            self.name,
+                            self.organization,
+                            self.job_args,
+                            job_labels,
+                        )
                     )
-                )
+                    logger.info(f"Workflow launched, URL: {job_url}")
+                    self.helper.update_action_state({"job_url": job_url})
+
+                # Monitor the job until completion
+                controller_job = await job_template_runner.monitor_job(job_url)
                 if controller_job["status"] != "failed":
                     break
+
+                # Reset job_url to launch a new job on retry
+                job_url = None
+                self.helper.update_action_state({"job_url": None})
         except (
             ControllerApiException,
             WorkflowJobTemplateNotFoundException,

--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -89,7 +89,7 @@ class RunWorkflowTemplate:
         add_event_uuid_label = self.action_args.get(
             "add_event_uuid_label", False
         )
-        job_labels = list(self.action_args.get("labels", []))
+        job_labels = list(self.action_args.get("labels") or [])
         if add_event_uuid_label:
             job_labels.append(self.helper.get_event_uuid_label())
 

--- a/ansible_rulebook/app.py
+++ b/ansible_rulebook/app.py
@@ -33,7 +33,7 @@ from ansible_rulebook.common import StartupArgs
 from ansible_rulebook.conf import settings
 from ansible_rulebook.engine import run_rulesets, start_source
 from ansible_rulebook.job_template_runner import job_template_runner
-from ansible_rulebook.rule_types import RuleSet, RuleSetQueue
+from ansible_rulebook.rule_types import EventSource, RuleSet, RuleSetQueue
 from ansible_rulebook.util import (
     decryptable,
     decrypted_context,
@@ -50,6 +50,7 @@ from ansible_rulebook.websocket import (
 
 from .exception import (
     ControllerNeededException,
+    DuplicateSourceNamesException,
     InvalidUrlException,
     InventoryNeededException,
     InventoryNotFound,
@@ -259,7 +260,16 @@ def spawn_sources(
     ruleset_queues = []
     for ruleset in rulesets:
         source_queue = asyncio.Queue(1)
+        source_feedback_queues = {}
+        source_names = []
         for source in ruleset.sources:
+            feedback_queue = _get_feedback_queue(
+                source, source_names, source_feedback_queues
+            )
+            if feedback_queue:
+                source_feedback_queues[source.name] = feedback_queue
+
+            source_names.append(source.name)
             task = asyncio.create_task(
                 start_source(
                     source,
@@ -268,11 +278,43 @@ def spawn_sources(
                     source_queue,
                     shutdown_delay,
                     filter_dirs,
+                    feedback_queue,
                 )
             )
             tasks.append(task)
-        ruleset_queues.append(RuleSetQueue(ruleset, source_queue))
+        ruleset_queues.append(
+            RuleSetQueue(ruleset, source_queue, source_feedback_queues)
+        )
     return tasks, ruleset_queues
+
+
+def _get_feedback_queue(
+    source: EventSource,
+    source_names: List[str],
+    source_feedback_queues: Dict[str, asyncio.Queue],
+) -> Optional[asyncio.Queue]:
+    feedback_queue = None
+    if (
+        settings.persistence_enabled
+        and source.source_args
+        and source.source_args.get("feedback", False)
+    ):
+        if (
+            source.name in source_feedback_queues
+            or source.name in source_names
+        ):
+            msg = (
+                "To support feedback when multiple sources "
+                "are defined in a ruleset, it is recommended "
+                "that each source have a unique name to prevent "
+                "conflicts and the feedbacks get sent to the "
+                "correct source plugin"
+            )
+            raise DuplicateSourceNamesException(msg)
+
+        feedback_queue = asyncio.Queue(1)
+
+    return feedback_queue
 
 
 def validate_variables(startup_args: StartupArgs) -> None:

--- a/ansible_rulebook/cli.py
+++ b/ansible_rulebook/cli.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import logging
 import os
+import signal
 import sys
 from typing import List
 
@@ -143,6 +144,11 @@ def get_parser() -> argparse.ArgumentParser:
         "--id",
         help="Identifier, the activation_instance id which allows "
         "the results to be communicated back to the websocket.",
+    )
+    parser.add_argument(
+        "--persistence-id",
+        help="Identifier, the persistence id which allows "
+        "for the data to be saved across multiple restarts.",
     )
     parser.add_argument(
         "-w",
@@ -332,6 +338,22 @@ def parse_vault_passwords(args: argparse.Namespace) -> None:
     )
 
 
+def setup_signal_handlers() -> None:
+    """Setup signal handlers for graceful shutdown."""
+
+    def signal_handler(signum, frame):
+        sig_name = signal.Signals(signum).name
+        logger.info(
+            f"Received signal {sig_name} ({signum}), initiating shutdown"
+        )
+        raise KeyboardInterrupt(f"Signal {sig_name} received")
+
+    # Register handlers for SIGTERM and SIGINT
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    logger.debug("Signal handlers registered for SIGTERM and SIGINT")
+
+
 def main(args: List[str] = None) -> int:
     parser = get_parser()
     if len(sys.argv) == 1:
@@ -342,6 +364,7 @@ def main(args: List[str] = None) -> int:
     validate_args(args)
     update_settings(args)
     setup_logging_and_display(args)
+    setup_signal_handlers()
 
     if args.controller_url:
         job_template_runner.host = args.controller_url

--- a/ansible_rulebook/conf.py
+++ b/ansible_rulebook/conf.py
@@ -36,6 +36,7 @@ class _Settings:
         self.vault = Vault()
         self.ansible_galaxy_path = shutil.which("ansible-galaxy")
         self.eda_labels = [DEFAULT_EDA_LABEL]
+        self.persistence_enabled = False
 
 
 settings = _Settings()

--- a/ansible_rulebook/engine.py
+++ b/ansible_rulebook/engine.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from drools.dispatch import establish_async_channel, handle_async_messages
-from drools.ruleset import session_stats
+from drools.ruleset import session_stats, shutdown as drools_shutdown
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -34,6 +34,7 @@ from ansible_rulebook.collection import (
     split_collection_name,
 )
 from ansible_rulebook.messages import Shutdown
+from ansible_rulebook.persistence import enable_leader, enable_persistence
 from ansible_rulebook.rule_set_runner import RuleSetRunner
 from ansible_rulebook.rule_types import (
     EventSource,
@@ -119,6 +120,7 @@ async def start_source(
     queue: asyncio.Queue,
     shutdown_delay: float = 60.0,
     filter_dirs: Optional[list[str]] = None,
+    source_feedback_queue: asyncio.Queue = None,
 ) -> None:
     all_source_queues.append(queue)
     try:
@@ -210,6 +212,8 @@ async def start_source(
                 source_name=source.source_name
             )
 
+        if source_feedback_queue:
+            args["eda_feedback_queue"] = source_feedback_queue
         await entrypoint(fqueue, args)
         shutdown_msg = (
             f"Source {source.source_name} initiated shutdown at "
@@ -221,6 +225,7 @@ async def start_source(
             f"Source {source.source_name} keyboard interrupt, "
             + f"initiated shutdown at {str(datetime.now())}"
         )
+        drools_shutdown()
         pass
     except asyncio.CancelledError:
         shutdown_msg = (
@@ -306,6 +311,12 @@ async def run_rulesets(
     file_monitor: str = None,
 ) -> bool:
     logger.debug("run_ruleset")
+    reader, writer = await establish_async_channel()
+    async_task = asyncio.create_task(
+        handle_async_messages(reader, writer), name="drools_async_task"
+    )
+
+    enable_persistence(parsed_args, variables)
     rulesets_queue_plans = rule_generator.generate_rulesets(
         ruleset_queues, variables, inventory
     )
@@ -319,7 +330,8 @@ async def run_rulesets(
     hosts_facts = []
     ruleset_names = []
     rulesets = {}
-    for ruleset, _ in ruleset_queues:
+    enable_leader()
+    for ruleset, _, _ in ruleset_queues:
         if ruleset.gather_facts and not hosts_facts:
             if inventory:
                 hosts_facts = collect_ansible_facts(inventory)
@@ -332,11 +344,6 @@ async def run_rulesets(
         rulesets[ruleset.name] = ruleset
 
     ruleset_tasks = []
-    reader, writer = await establish_async_channel()
-    async_task = asyncio.create_task(
-        handle_async_messages(reader, writer), name="drools_async_task"
-    )
-
     send_heartbeat_task = None
     if parsed_args and parsed_args.heartbeat > 0 and event_log:
         send_heartbeat_task = asyncio.create_task(

--- a/ansible_rulebook/exception.py
+++ b/ansible_rulebook/exception.py
@@ -214,3 +214,7 @@ class InvalidUrlException(Exception):
 
 class ControllerObjectCreateException(Exception):
     pass
+
+
+class DuplicateSourceNamesException(Exception):
+    pass

--- a/ansible_rulebook/job_template_runner.py
+++ b/ansible_rulebook/job_template_runner.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 
 CLIENT_CONNECT_ERROR_STRING = "Error connecting to controller: %s"
+JOB_TEMPLATE_TYPE = "job_template"
+WORKFLOW_TEMPLATE_TYPE = "workflow_template"
 
 
 class JobTemplateRunner:
@@ -127,15 +129,17 @@ class JobTemplateRunner:
         logger.info("Attempting to connect to Controller %s", self.host)
         return await self._get_page(self._config_slug, {})
 
-    def _auth_headers(self) -> dict:
+    def _auth_headers(self) -> Optional[dict]:
         if self.token:
             return dict(Authorization=f"Bearer {self.token}")
+        return None
 
-    def _basic_auth(self) -> aiohttp.BasicAuth:
+    def _basic_auth(self) -> Optional[aiohttp.BasicAuth]:
         if self.username and self.password:
             return aiohttp.BasicAuth(
                 login=self.username, password=self.password
             )
+        return None
 
     @cached_property
     def _sslcontext(self) -> Union[bool, ssl.SSLContext]:
@@ -148,7 +152,7 @@ class JobTemplateRunner:
 
     async def _get_template_obj(
         self, name: str, organization: str, unified_type: str
-    ) -> dict:
+    ) -> Optional[dict]:
         params = {"name": name}
 
         while True:
@@ -168,6 +172,7 @@ class JobTemplateRunner:
                     == organization
                 ):
                     return {
+                        "id": jt["id"],
                         "launch": dpath.get(jt, "related.launch", ".", None),
                         "ask_limit_on_launch": jt["ask_limit_on_launch"],
                         "ask_labels_on_launch": jt["ask_labels_on_launch"],
@@ -184,13 +189,35 @@ class JobTemplateRunner:
             else:
                 break
 
-    async def run_job_template(
+        return None
+
+    async def launch_job_template(
         self,
         name: str,
         organization: str,
         job_params: dict,
         labels: Optional[list[str]] = None,
-    ) -> dict:
+    ) -> str:
+        """Launch a job template and return the job URL immediately.
+
+        This method initiates a job template execution on the controller
+        and returns immediately with the job URL without waiting for
+        completion. This enables asynchronous job monitoring.
+
+        Args:
+            name: Name of the job template to launch
+            organization: Organization name containing the job template
+            job_params: Dictionary of parameters to pass to the job (e.g.,
+                extra_vars, inventory, limit)
+            labels: Optional list of label names to attach to the job
+
+        Returns:
+            str: The job URL for monitoring
+
+        Raises:
+            JobTemplateNotFoundException: If the specified job template
+                does not exist in the organization
+        """
         obj = await self._get_template_obj(name, organization, "job_template")
         if not obj:
             raise JobTemplateNotFoundException(
@@ -213,15 +240,69 @@ class JobTemplateRunner:
 
         url = urljoin(self.host, obj["launch"])
         job = await self._launch(job_params, url)
-        return await self._monitor_job(job["url"])
+        return job["url"]
 
-    async def run_workflow_job_template(
+    async def run_job_template(
         self,
         name: str,
         organization: str,
         job_params: dict,
         labels: Optional[list[str]] = None,
     ) -> dict:
+        """Launch a job template and wait for it to complete.
+
+        This method combines launching a job template with monitoring its
+        execution until completion. It's a convenience wrapper around
+        launch_job_template() and monitor_job().
+
+        Args:
+            name: Name of the job template to run
+            organization: Organization name containing the job template
+            job_params: Dictionary of parameters to pass to the job
+            labels: Optional list of label names to attach to the job
+
+        Returns:
+            dict: The final job status information including status, artifacts,
+                and other job metadata
+
+        Raises:
+            JobTemplateNotFoundException: If the specified job template
+                does not exist in the organization
+        """
+        job_url = await self.launch_job_template(
+            name, organization, job_params, labels
+        )
+        return await self.monitor_job(job_url)
+
+    async def launch_workflow_job_template(
+        self,
+        name: str,
+        organization: str,
+        job_params: dict,
+        labels: Optional[list[str]] = None,
+    ) -> str:
+        """Launch a workflow job template and return the job URL immediately.
+
+        This method initiates a workflow job template execution on the
+        controller and returns immediately with the job URL without waiting
+        for completion. Workflows may not support all parameters that regular
+        job templates do (e.g., limit parameter).
+
+        Args:
+            name: Name of the workflow job template to launch
+            organization: Organization name containing the workflow template
+            job_params: Dictionary of parameters to pass to the workflow
+                (e.g., extra_vars, inventory). Note: 'limit' is removed if
+                the workflow template doesn't accept it.
+            labels: Optional list of label names to attach to the workflow job
+
+        Returns:
+            str: The workflow job URL for monitoring
+
+        Raises:
+            WorkflowJobTemplateNotFoundException: If the specified workflow
+                template does not exist in the organization
+        """
         obj = await self._get_template_obj(
             name, organization, "workflow_job_template"
         )
@@ -251,9 +332,54 @@ class JobTemplateRunner:
             )
             job_params.pop("limit")
         job = await self._launch(job_params, url)
-        return await self._monitor_job(job["url"])
+        return job["url"]
 
-    async def _monitor_job(self, url) -> dict:
+    async def run_workflow_job_template(
+        self,
+        name: str,
+        organization: str,
+        job_params: dict,
+        labels: Optional[list[str]] = None,
+    ) -> dict:
+        """Launch a workflow job template and wait for it to complete.
+
+        This method combines launching a workflow job template with monitoring
+        its execution until completion. It's a convenience wrapper around
+        launch_workflow_job_template() and monitor_job().
+
+        Args:
+            name: Name of the workflow job template to run
+            organization: Organization name containing the workflow template
+            job_params: Dictionary of parameters to pass to the workflow
+            labels: Optional list of label names to attach to the workflow job
+
+        Returns:
+            dict: The final workflow job status information including status,
+                artifacts, and other job metadata
+
+        Raises:
+            WorkflowJobTemplateNotFoundException: If the specified workflow
+                template does not exist in the organization
+        """
+        job_url = await self.launch_workflow_job_template(
+            name, organization, job_params, labels
+        )
+        return await self.monitor_job(job_url)
+
+    async def monitor_job(self, url) -> dict:
+        """Monitor a running job until it reaches a completion status.
+
+        This method polls the controller for job status updates at regular
+        intervals until the job reaches a terminal state (successful, failed,
+        error, or canceled).
+
+        Args:
+            url: The job URL to monitor (can be a regular job or workflow job)
+
+        Returns:
+            dict: The final job status information when the job completes,
+                including status, artifacts, and other job metadata
+        """
         while True:
             # fetch and process job status
             json_body = await self._get_page(url, {})
@@ -292,7 +418,7 @@ class JobTemplateRunner:
 
     async def _create_obj(
         self, href_slug: str, params: dict
-    ) -> (Optional[dict], bool):
+    ) -> tuple[Optional[dict], bool]:
         body = None
         try:
             url = urljoin(self.host, href_slug)
@@ -394,6 +520,81 @@ class JobTemplateRunner:
                 name,
             )
         return []
+
+    def _api_slug_prefix(self) -> str:
+        return self._unified_job_template_slug.split("unified_job_templates/")[
+            0
+        ]
+
+    async def get_job_url_from_label(
+        self, name: str, organization: str, obj_type: str, label: str
+    ) -> Optional[str]:
+        """Retrieve a job URL by searching for a job with a specific label.
+
+        This method searches for jobs or workflow jobs associated with a
+        template that have been tagged with a specific label. This is useful
+        in HA/persistence scenarios where a job was launched in a previous
+        execution and needs to be found and monitored.
+
+        Args:
+            name: Name of the job or workflow template
+            organization: Organization name containing the template
+            obj_type: Type of template ("job_template" or
+                "workflow_template")
+            label: Label name to search for (e.g., "eda-event-uuid-{uuid}")
+
+        Returns:
+            Optional[str]: The job URL if a job with the label is found,
+                None if no matching job exists
+
+        Raises:
+            JobTemplateNotFoundException: If obj_type is "job_template"
+                and the template doesn't exist
+            WorkflowJobTemplateNotFoundException: If obj_type is
+                "workflow_template" and the template doesn't exist
+            ValueError: If obj_type is neither "job_template" nor
+                "workflow_template"
+        """
+        if obj_type == JOB_TEMPLATE_TYPE:
+            obj = await self._get_template_obj(
+                name, organization, "job_template"
+            )
+            if not obj:
+                raise JobTemplateNotFoundException(
+                    (
+                        f"Job template {name} in organization "
+                        f"{organization} does not exist"
+                    )
+                )
+            job_slug = (
+                f"{self._api_slug_prefix()}job_templates/{obj['id']}/jobs/"
+            )
+        elif obj_type == WORKFLOW_TEMPLATE_TYPE:
+            obj = await self._get_template_obj(
+                name, organization, "workflow_job_template"
+            )
+            if not obj:
+                raise WorkflowJobTemplateNotFoundException(
+                    (
+                        f"Workflow template {name} in organization "
+                        f"{organization} does not exist"
+                    )
+                )
+            job_slug = (
+                f"{self._api_slug_prefix()}"
+                f"workflow_job_templates/{obj['id']}/workflow_jobs/"
+            )
+        else:
+            raise ValueError(
+                f"Invalid type {obj_type} passed into job_url_from_label"
+            )
+
+        params = {"labels__name": label}
+        result = await self._get_page(job_slug, params)
+        if result["count"] >= 1:
+            return result["results"][0]["url"]
+
+        return None
 
 
 job_template_runner = JobTemplateRunner()

--- a/ansible_rulebook/persistence.py
+++ b/ansible_rulebook/persistence.py
@@ -1,0 +1,314 @@
+"""
+Persistence module for ansible-rulebook.
+
+This module provides functionality for enabling and managing persistence
+of rulebook execution state using either PostgreSQL or H2 databases.
+It supports high availability (HA) mode by storing action states and
+enabling leader election among multiple rulebook instances.
+"""
+
+import argparse
+import json
+import logging
+from typing import Dict, Optional
+
+import dpath
+from drools import ruleset as lang
+
+from ansible_rulebook.conf import settings
+from ansible_rulebook.util import strtobool
+
+logger = logging.getLogger(__name__)
+
+# Required configuration keys for PostgreSQL database connection
+POSTGRES_REQUIRED_KEYS = {
+    "drools_db_host",
+    "drools_db_port",
+    "drools_db_name",
+}
+
+# Required configuration keys for H2 embedded database
+H2_REQUIRED_KEYS = {"drools_db_file_path"}
+
+
+def enable_persistence(
+    parsed_args: argparse.Namespace, variables: Dict
+) -> None:
+    """
+    Enable persistence for the rulebook execution.
+
+    This function initializes the high availability (HA) mode with database
+    persistence for storing rulebook state. It supports both PostgreSQL and
+    H2 databases.
+
+    Args:
+        parsed_args: Command-line arguments containing persistence_id and id
+        variables: Dictionary containing database connection parameters
+
+    Returns:
+        None. Sets settings.persistence_enabled if successful.
+    """
+    # Reset persistence_enabled to False at the start to ensure clean state
+    # This is important for test isolation when multiple tests run in sequence
+    settings.persistence_enabled = False
+
+    if parsed_args is None:
+        return
+    if parsed_args.persistence_id is None:
+        return
+    # Try to get database parameters, first from PostgreSQL config, then H2
+    db_params = _get_postgres_params(variables) or _get_h2_params(variables)
+    if db_params is None:
+        # No valid database configuration found, persistence remains disabled
+        return
+
+    # This should be a UUID but the backend currently does not
+    # use UUID's it uses integer ids
+    activation_uuid = f"{parsed_args.persistence_id}"
+    worker_name = f"instance-{parsed_args.id}"
+
+    # Get additional configuration parameters like sync intervals
+    # and encryption
+    config = _get_config_params(variables)
+
+    logger.info(
+        "Initializing drools HA mode: worker_id=%s, database=%s, ha_uuid=%s",
+        activation_uuid,
+        db_params["db_type"],
+        activation_uuid,
+    )
+
+    # Initialize the high availability system in the drools engine
+    lang.initialize_ha(
+        uuid=activation_uuid,
+        worker_name=worker_name,
+        db_params=db_params,
+        config=config,
+    )
+    settings.persistence_enabled = True
+
+
+def update_action_info(
+    rule_set: str,
+    matching_uuid: str,
+    index: int,
+    info: dict,
+    create: bool = False,
+) -> None:
+    """
+    Update or create action information in the persistence store.
+
+    This function stores action execution state in the database, allowing
+    actions to be tracked and recovered across rulebook restarts or failover.
+
+    Args:
+        rule_set: Name of the ruleset containing the action
+        matching_uuid: Unique identifier for the rule matching that
+            triggered the action
+        index: Index of the action within the rule's action list
+        info: Dictionary containing action state information to store
+        create: If True, create new action info; if False, update existing
+
+    Returns:
+        None. Action info is persisted to the database if persistence
+        is enabled.
+    """
+    if not settings.persistence_enabled:
+        return
+
+    if create:
+        # Create a new action info record in the database
+        lang.add_action_info(rule_set, matching_uuid, index, json.dumps(info))
+    else:
+        # Update existing action info by merging new data with saved data
+        saved_data = lang.get_action_info(rule_set, matching_uuid, index)
+        if saved_data is None:
+            action_data = {}
+        else:
+            try:
+                action_data = json.loads(saved_data)
+            except json.JSONDecodeError as e:
+                logger.error("Error parsing saved action data  %s", e.msg)
+                action_data = {}
+
+        # Merge the new info into the existing data
+        for k, v in info.items():
+            action_data[k] = v
+        logger.debug("Updating action info %s", action_data)
+        lang.update_action_info(
+            rule_set, matching_uuid, index, json.dumps(action_data)
+        )
+
+
+def get_action_a_priori(
+    rule_set: str, matching_uuid: str, index: int
+) -> Optional[dict]:
+    """
+    Retrieve previously stored action information from persistence.
+
+    This function is used to recover action state from a previous execution,
+    which is essential for resuming long-running actions or maintaining state
+    across rulebook restarts in HA mode.
+
+    Args:
+        rule_set: Name of the ruleset containing the action
+        matching_uuid: Unique identifier for the rule matching
+        index: Index of the action within the rule's action list
+
+    Returns:
+        Dictionary containing the stored action data if it exists,
+        empty dict if data exists but is corrupted, or None if no data exists.
+    """
+    if lang.action_info_exists(rule_set, matching_uuid, index):
+        data = lang.get_action_info(rule_set, matching_uuid, index)
+        if data is None:
+            return {}
+        logger.debug("Previous action data %s", data)
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError as e:
+            logger.error("Error parsing prior action data  %s", e.msg)
+            return {}
+
+    return None
+
+
+def enable_leader():
+    """
+    Enable leader election for this rulebook instance.
+
+    In HA mode, this function designates the current instance as eligible
+    to become the leader. The leader instance is responsible for coordinating
+    distributed rule execution across multiple workers.
+
+    Returns:
+        None. Enables leader mode in the drools engine if persistence
+        is enabled.
+    """
+    if settings.persistence_enabled:
+        lang.enable_leader()
+
+
+def _get_postgres_params(variables: dict) -> Optional[dict]:
+    """
+    Extract PostgreSQL connection parameters from variables.
+
+    This function validates that required PostgreSQL connection parameters
+    are present and constructs a connection parameter dictionary including
+    optional SSL and authentication settings.
+
+    Args:
+        variables: Dictionary containing configuration variables
+
+    Returns:
+        Dictionary of PostgreSQL connection parameters if all required keys
+        are present, otherwise None.
+    """
+    # Check if all required PostgreSQL keys are present
+    if not POSTGRES_REQUIRED_KEYS <= set(variables.keys()):
+        return None
+
+    # Build basic connection parameters
+    db_params = {
+        "host": variables["drools_db_host"],
+        "port": variables["drools_db_port"],
+        "database": variables["drools_db_name"],
+    }
+    db_params["db_type"] = "postgres"
+
+    # Map optional parameters from variables to database parameter names
+    # Supports both direct variable names and EDA filename paths
+    mappings = {
+        "drools_db_user": "user",
+        "drools_db_password": "password",
+        "drools_sslmode": "sslmode",
+        "drools_sslpassword": "sslpassword",
+        "eda/filename/drools_sslrootcert": "sslrootcert",
+        "eda/filename/drools_sslkey": "sslkey",
+        "eda/filename/drools_sslcert": "sslcert",
+        "drools_sslcert": "sslcert",
+        "drools_sslrootcert": "sslrootcert",
+        "drools_sslkey": "sslkey",
+    }
+
+    # Add optional parameters if they exist in variables
+    for key, mapped_name in mappings.items():
+        value = dpath.get(variables, key, default=None)
+        if value:
+            db_params[mapped_name] = value
+
+    return db_params
+
+
+def _get_h2_params(variables: dict) -> Optional[dict]:
+    """
+    Extract H2 database connection parameters from variables.
+
+    H2 is a lightweight embedded database suitable for development and
+    single-instance deployments. This function validates and extracts
+    the required file path parameter.
+
+    Args:
+        variables: Dictionary containing configuration variables
+
+    Returns:
+        Dictionary of H2 connection parameters if required keys are present,
+        otherwise None.
+    """
+    # Check if required H2 file path key is present
+    if not H2_REQUIRED_KEYS <= set(variables.keys()):
+        return None
+
+    return {"db_type": "h2", "db_file_path": variables["drools_db_file_path"]}
+
+
+def _get_config_params(variables: dict) -> dict:
+    """
+    Extract additional configuration parameters for HA mode.
+
+    This function builds configuration parameters for the high availability
+    system including synchronization intervals, encryption keys, and grace
+    periods for expired time windows.
+
+    Args:
+        variables: Dictionary containing configuration variables
+
+    Returns:
+        Dictionary of configuration parameters with default values for
+        sync intervals and optional encryption and grace period settings.
+    """
+    # Set default synchronization intervals (in milliseconds)
+    result = {}
+
+    # Add primary encryption key if provided
+    if variables.get("drools_primary_encryption_secret"):
+        result["encryption_key_primary"] = variables.get(
+            "drools_primary_encryption_secret"
+        )
+
+    # Add secondary encryption key if provided (for key rotation)
+    if variables.get("drools_secondary_encryption_secret"):
+        result["encryption_key_secondary"] = variables.get(
+            "drools_secondary_encryption_secret"
+        )
+
+    # Add grace period for expired time windows if provided
+    if variables.get("drools_expired_window_grace_period"):
+        result["expired_window_grace_period"] = int(
+            variables.get("drools_expired_window_grace_period")
+        )
+
+    # Add overwrite if provided
+    if "drools_overwrite_if_rulebook_changes" in variables:
+        data = variables.get("drools_overwrite_if_rulebook_changes", False)
+        if isinstance(data, bool):
+            result["overwrite_if_rulebook_changes"] = data
+        else:
+            result["overwrite_if_rulebook_changes"] = strtobool(str(data))
+
+    # Add dedup buffer size
+    if variables.get("drools_deduplication_window_size"):
+        result["dedup_buffer_size"] = int(
+            variables.get("drools_deduplication_window_size")
+        )
+    return result

--- a/ansible_rulebook/rule_generator.py
+++ b/ansible_rulebook/rule_generator.py
@@ -94,7 +94,11 @@ def generate_rulesets(
 
     rulesets = []
 
-    for ansible_ruleset, source_queue in ruleset_queues:
+    for (
+        ansible_ruleset,
+        source_queue,
+        source_feedback_queues,
+    ) in ruleset_queues:
         ruleset_ast = visit_ruleset(ansible_ruleset, variables)
         drools_ruleset = DroolsRuleset(
             name=ansible_ruleset.name,
@@ -117,6 +121,8 @@ def generate_rulesets(
                 )
 
         rulesets.append(
-            EngineRuleSetQueuePlan(drools_ruleset, source_queue, plan)
+            EngineRuleSetQueuePlan(
+                drools_ruleset, source_queue, plan, source_feedback_queues
+            )
         )
     return rulesets

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -33,7 +33,12 @@ from drools.ruleset import session_stats
 from ansible_rulebook import terminal
 from ansible_rulebook.action.control import Control
 from ansible_rulebook.action.debug import Debug
-from ansible_rulebook.action.metadata import Metadata
+from ansible_rulebook.action.helper import (
+    FAILED_STATUS,
+    STARTED_STATUS,
+    SUCCESSFUL_STATUS,
+)
+from ansible_rulebook.action.metadata import ActionPersistence, Metadata
 from ansible_rulebook.action.noop import Noop
 from ansible_rulebook.action.pg_notify import PGNotify
 from ansible_rulebook.action.post_event import PostEvent
@@ -51,6 +56,10 @@ from ansible_rulebook.exception import (
     UnsupportedActionException,
 )
 from ansible_rulebook.messages import Shutdown
+from ansible_rulebook.persistence import (
+    get_action_a_priori,
+    update_action_info,
+)
 from ansible_rulebook.rule_types import (
     Action,
     ActionContext,
@@ -64,6 +73,8 @@ from ansible_rulebook.util import (
     send_session_stats,
     substitute_variables,
 )
+
+COMPLETED_STATUSES = [FAILED_STATUS, SUCCESSFUL_STATUS]
 
 logger = logging.getLogger(__name__)
 
@@ -248,6 +259,25 @@ class RuleSetRunner:
                         str(data),
                     )
                     lang.post(self.name, data)
+
+                    try:
+                        source_name = dpath.get(data, "meta/source/name")
+                    except KeyError:
+                        source_name = None
+
+                    if (
+                        source_name
+                        and source_name
+                        in self.ruleset_queue_plan.source_feedback_queues
+                    ):
+                        feedback_queue = (
+                            self.ruleset_queue_plan.source_feedback_queues.get(
+                                source_name
+                            )
+                        )
+                        await feedback_queue.put(data)
+                except asyncio.CancelledError:
+                    raise
                 except MessageObservedException:
                     logger.debug("MessageObservedException: %s", data)
                 except MessageNotHandledException:
@@ -361,11 +391,23 @@ class RuleSetRunner:
     async def _run_multiple_actions(
         self, action_item: ActionContext, rule_run_at: str
     ) -> None:
-        for action in action_item.actions:
-            await self._run_action(action, action_item, rule_run_at)
+        number_of_actions = len(action_item.actions)
+        for index, action in enumerate(action_item.actions):
+            await self._run_action(
+                action,
+                action_item,
+                rule_run_at,
+                index,
+                index == (number_of_actions - 1),
+            )
 
     def _run_action(
-        self, action: Action, action_item: ActionContext, rule_run_at: str
+        self,
+        action: Action,
+        action_item: ActionContext,
+        rule_run_at: str,
+        index: int = 0,
+        last_action: bool = True,
     ) -> asyncio.Task:
         task_name = (
             f"action::{action.action}::"
@@ -373,12 +415,35 @@ class RuleSetRunner:
             f"{action_item.rule}"
         )
         logger.debug("Creating action task %s", task_name)
+        persistent_info = None
+        matching_uuid = action_item.rule_engine_results.matching_uuid
+        if matching_uuid:
+            a_priori = None
+            a_priori = get_action_a_priori(
+                action_item.ruleset, matching_uuid, index
+            )
+            if a_priori is None:
+                update_action_info(
+                    action_item.ruleset,
+                    matching_uuid,
+                    index,
+                    {"status": STARTED_STATUS},
+                    True,
+                )
+            persistent_info = ActionPersistence(
+                matching_uuid=matching_uuid,
+                action_index=index,
+                last_action=last_action,
+                a_priori=a_priori,
+            )
+
         metadata = Metadata(
             rule_set=action_item.ruleset,
             rule_set_uuid=action_item.ruleset_uuid,
             rule=action_item.rule,
             rule_uuid=action_item.rule_uuid,
             rule_run_at=rule_run_at,
+            persistent_info=persistent_info,
         )
 
         task = asyncio.create_task(
@@ -410,7 +475,29 @@ class RuleSetRunner:
         logger.debug("call_action %s", action)
         action_args = immutable_action_args.copy()
 
+        if (
+            metadata.persistent_info
+            and metadata.persistent_info.a_priori
+            and metadata.persistent_info.a_priori.get("status")
+            in COMPLETED_STATUSES
+        ):
+            logger.warning(
+                "Skipping action %s already ran %s",
+                action,
+                metadata.persistent_info.a_priori.get("status"),
+            )
+            if (
+                metadata.persistent_info
+                and metadata.persistent_info.last_action
+            ):
+                lang.delete_action_info(
+                    metadata.rule_set, metadata.persistent_info.matching_uuid
+                )
+            return
+
         error = None
+        action_status = FAILED_STATUS
+        cancelled = False
         if action in ACTION_CLASSES:
             try:
                 if (
@@ -495,13 +582,14 @@ class RuleSetRunner:
                         control,
                         action_args,
                     )
+                    action_status = SUCCESSFUL_STATUS
                 else:
                     await ACTION_CLASSES[action](
                         metadata,
                         control,
                         **action_args,
                     )()
-
+                    action_status = SUCCESSFUL_STATUS
             except KeyError as e:
                 logger.error(
                     "KeyError %s with variables %s",
@@ -526,6 +614,7 @@ class RuleSetRunner:
                     await self.broadcast_method(e.shutdown)
             except asyncio.CancelledError:
                 logger.debug("Action task caught Cancelled error")
+                cancelled = True
                 raise
             except jinja2_exceptions.UndefinedError as e:
                 error = e
@@ -544,6 +633,24 @@ class RuleSetRunner:
             except BaseException as e:
                 logger.error(e)
                 raise
+            finally:
+                if (
+                    metadata.persistent_info
+                    and metadata.persistent_info.matching_uuid
+                    and not cancelled
+                ):
+                    if metadata.persistent_info.last_action:
+                        lang.delete_action_info(
+                            metadata.rule_set,
+                            metadata.persistent_info.matching_uuid,
+                        )
+                    else:
+                        update_action_info(
+                            metadata.rule_set,
+                            metadata.persistent_info.matching_uuid,
+                            metadata.persistent_info.action_index,
+                            {"status": action_status},
+                        )
         else:
             logger.error("Action %s not supported", action)
             error = UnsupportedActionException(

--- a/ansible_rulebook/rule_types.py
+++ b/ansible_rulebook/rule_types.py
@@ -98,6 +98,7 @@ class ActionContext(NamedTuple):
 class RuleSetQueue(NamedTuple):
     ruleset: RuleSet
     source_queue: asyncio.Queue
+    source_feedback_queues: dict[str, asyncio.Queue]
 
 
 @dataclass
@@ -109,3 +110,4 @@ class EngineRuleSetQueuePlan(NamedTuple):
     ruleset: EngineRuleSet
     source_queue: asyncio.Queue
     plan: Plan
+    source_feedback_queues: dict[str, asyncio.Queue]

--- a/ansible_rulebook/schema/ruleset_schema.json
+++ b/ansible_rulebook/schema/ruleset_schema.json
@@ -487,6 +487,10 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "add_event_uuid_label": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "required": [
@@ -549,6 +553,10 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "add_event_uuid_label": {
+                            "type": "boolean",
+                            "default": false
                         }
                     },
                     "required": [

--- a/docs/actions.rst
+++ b/docs/actions.rst
@@ -199,6 +199,9 @@ Run a job template.
    * - labels
      - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible". If the label gets resolved as None or an empty string it will be dropped. If there are duplicate labels the duplicate ones will be removed. e.g {{ event.payload.my_label | default(None) }} if the attribute doesn't exist we will skip the label.
      - No
+   * - add_event_uuid_label
+     - A boolean field, when set to true can leverage the event.meta.uuid field as a label, you can establish clear traceability between triggering events and their resulting jobs.
+     - No
 
 run_workflow_template
 *********************
@@ -263,6 +266,9 @@ Run a workflow template.
      - No
    * - labels
      - Optional list of strings as labels, which can be added to the job in the controller. Requires that Prompt on launch for Labels is enabled. If its not enabled the labels are ignored. ansible-rulebook will add a default label called "Activated by Event-Driven Ansible". If the label gets resolved as None or an empty string it will be dropped. If there are duplicate labels the duplicate ones will be removed. e.g {{ event.payload.my_label | default(None) }} if the attribute doesn't exist we will skip the label.
+     - No
+   * - add_event_uuid_label
+     - A boolean field, when set to true can leverage the event.meta.uuid field as a label, you can establish clear traceability between triggering events and their resulting jobs.
      - No
 post_event
 **********

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,6 +18,7 @@ The `ansible-rulebook` CLI supports the following options:
                         [--execution-strategy {sequential,parallel}] [--hot-reload] [--skip-audit-events]
                         [--vault-password-file VAULT_PASSWORD_FILE] [--vault-id VAULT_ID] [--ask-vault-pass]
                         [-F FILTER_DIR]
+                        [--persistence-id PERSISTENCE_ID]
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -72,6 +73,8 @@ The `ansible-rulebook` CLI supports the following options:
                             The file containing one ansible vault password, can also be passed via the env var EDA_VAULT_PASSWORD_FILE.
     --vault-id VAULT_ID   label@filename pointing to an ansible vault password file
     --ask-vault-pass      Ask vault password interactively 
+    --persistence-id   PERSISTENCE_ID 
+                         The unique id, preferably a UUID to track persistent event data
 
 To get help from `ansible-rulebook` run the following:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 	janus >=1,<2
 	ansible-runner >=2,<3
         websockets >=15,<15.1
-	drools_jpy == 0.3.14
+	drools_jpy @ git+https://github.com/tkobayas/drools_jpy.git@ha-poc-0.0.10
 	watchdog >=3,<7
 	xxhash >=3,<4
     pyyaml >=6,<7
@@ -49,8 +49,7 @@ console_scripts =
 
 [flake8]
 extend-exclude = docs, venv, .venv
-extend-ignore =
-	E203,  #  Whitespace before ':' (false positive in slices, handled by black.
+extend-ignore = E203
 
 [options.extras_require]
 production =

--- a/tests/data/awx_test_data.py
+++ b/tests/data/awx_test_data.py
@@ -9,6 +9,7 @@ JOB_TEMPLATE_1_LAUNCH_SLUG = "api/v2/job_templates/255/launch/"
 JOB_TEMPLATE_2_LAUNCH_SLUG = "api/v2/workflow_job_templates/300/launch/"
 
 JOB_TEMPLATE_1 = {
+    "id": 255,
     "type": "job_template",
     "name": JOB_TEMPLATE_NAME_1,
     "ask_limit_on_launch": False,
@@ -20,6 +21,7 @@ JOB_TEMPLATE_1 = {
 }
 
 JOB_TEMPLATE_1_NO_LABELS = {
+    "id": 255,
     "type": "job_template",
     "name": JOB_TEMPLATE_NAME_1,
     "ask_limit_on_launch": False,
@@ -31,6 +33,7 @@ JOB_TEMPLATE_1_NO_LABELS = {
 }
 
 JOB_TEMPLATE_2 = {
+    "id": 300,
     "type": "workflow_job_template",
     "name": JOB_TEMPLATE_NAME_1,
     "ask_limit_on_launch": False,
@@ -41,6 +44,7 @@ JOB_TEMPLATE_2 = {
 }
 
 JOB_TEMPLATE_2_NO_LABELS = {
+    "id": 300,
     "type": "workflow_job_template",
     "name": JOB_TEMPLATE_NAME_1,
     "ask_limit_on_launch": False,

--- a/tests/e2e/config/default.yml
+++ b/tests/e2e/config/default.yml
@@ -2,7 +2,7 @@ default_event_delay: 1
 default_shutdown_after: 5
 default_startup_delay: 30
 operators_shutdown_after: 1
-shutdown_now_startup_delay: 0.5
+shutdown_now_startup_delay: 2
 disabled_rules_event_delay: 0.5
 cmd_timeout: 25
 controller_url: http://localhost:8080

--- a/tests/e2e/files/data/items.json
+++ b/tests/e2e/files/data/items.json
@@ -1,0 +1,62 @@
+[
+    {
+        "i": 1,
+        "meta": {
+            "uuid": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+        }
+    },
+    {
+        "i": 2,
+        "meta": {
+            "uuid": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e"
+        }
+    },
+    {
+        "i": 3,
+        "meta": {
+            "uuid": "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
+        }
+    },
+    {
+        "i": 4,
+        "meta": {
+            "uuid": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f8a"
+        }
+    },
+    {
+        "i": 5,
+        "meta": {
+            "uuid": "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b"
+        }
+    },
+    {
+        "i": 6,
+        "meta": {
+            "uuid": "f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f8a9b0c"
+        }
+    },
+    {
+        "i": 7,
+        "meta": {
+            "uuid": "a7b8c9d0-e1f2-4a3b-4c5d-6e7f8a9b0c1d"
+        }
+    },
+    {
+        "i": 8,
+        "meta": {
+            "uuid": "b8c9d0e1-f2a3-4b4c-5d6e-7f8a9b0c1d2e"
+        }
+    },
+    {
+        "i": 9,
+        "meta": {
+            "uuid": "c9d0e1f2-a3b4-4c5d-6e7f-8a9b0c1d2e3f"
+        }
+    },
+    {
+        "i": 10,
+        "meta": {
+            "uuid": "d0e1f2a3-b4c5-4d6e-7f8a-9b0c1d2e3f4a"
+        }
+    }
+]

--- a/tests/e2e/files/extra_vars/drools_db_vars.yml
+++ b/tests/e2e/files/extra_vars/drools_db_vars.yml
@@ -1,0 +1,3 @@
+---
+drools_db_type: h2
+json_data_file: /tmp/items.json

--- a/tests/e2e/files/rulebooks/persistence/multi_event_rule.yml
+++ b/tests/e2e/files/rulebooks/persistence/multi_event_rule.yml
@@ -1,0 +1,17 @@
+---
+- name: Multi Event Rule
+  hosts: localhost
+  sources:
+    - json_event_queue:
+        file: "{{ json_data_file }}"
+        delay: 2
+        feedback: true
+  rules:
+    - name: r1
+      condition:
+        all:
+           - event.i == 1
+           - event.i == 3
+           - event.i == 7
+      actions:
+        - debug:

--- a/tests/e2e/files/rulebooks/persistence/single_event_different_rules.yml
+++ b/tests/e2e/files/rulebooks/persistence/single_event_different_rules.yml
@@ -1,0 +1,21 @@
+---
+- name: Single Event Different Rules
+  hosts: localhost
+  sources:
+    - json_event_queue:
+        file: "{{ json_data_file }}"
+        delay: 2
+        feedback: true
+  rules:
+    - name: r1
+      condition: event.i == 1
+      actions:
+        - debug:
+    - name: r5
+      condition: event.i == 5
+      actions:
+        - debug:
+    - name: r9
+      condition: event.i == 9
+      actions:
+        - print_event:

--- a/tests/e2e/files/rulebooks/persistence/single_event_rule.yml
+++ b/tests/e2e/files/rulebooks/persistence/single_event_rule.yml
@@ -1,0 +1,13 @@
+---
+- name: Single Event Rule
+  hosts: localhost
+  sources:
+    - json_event_queue:
+        file: "{{ json_data_file }}"
+        delay: 2
+        feedback: true
+  rules:
+    - name: r1
+      condition: event.i < 5
+      actions:
+        - debug:

--- a/tests/e2e/test_multi_restart.py
+++ b/tests/e2e/test_multi_restart.py
@@ -1,0 +1,695 @@
+"""
+Test ansible-rulebook with periodic process restarts
+to verify event persistence and recovery
+"""
+
+import asyncio
+import fcntl
+import logging
+import os
+import platform
+import shutil
+import signal
+import tempfile
+import time
+import uuid
+from contextlib import asynccontextmanager
+from functools import partial
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import dpath
+import pytest
+import websockets.asyncio.server as ws_server
+import yaml
+
+from . import utils
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_TIMEOUT = 30
+RESTART_INTERVAL = 3  # seconds between restarts
+NUM_RESTARTS = 3  # number of times to restart the process
+
+TEST_DATA = [
+    (
+        {
+            "rules_triggered": 1,
+            "events_processed": 10,
+            "events_matched": 3,
+            "number_of_actions": 1,
+            "number_of_session_stats": 6,
+            "number_of_rules": 1,
+            "number_of_disabled_rules": 0,
+        },
+        utils.BASE_DATA_PATH / "rulebooks/persistence/multi_event_rule.yml",
+        [
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [
+                    {"key": "m_2/i", "value": 7},
+                    {"key": "m_0/i", "value": 1},
+                    {"key": "m_1/i", "value": 3},
+                ],
+            },
+        ],
+        "Multi Event Rule",
+    ),
+    (
+        {
+            "rules_triggered": 4,
+            "events_processed": 10,
+            "events_matched": 4,
+            "number_of_actions": 4,
+            "number_of_session_stats": 6,
+            "number_of_rules": 1,
+            "number_of_disabled_rules": 0,
+        },
+        utils.BASE_DATA_PATH / "rulebooks/persistence/single_event_rule.yml",
+        [
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 2}],
+            },
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 1}],
+            },
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 4}],
+            },
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 3}],
+            },
+        ],
+        "Single Event Rule",
+    ),
+    (
+        {
+            "rules_triggered": 3,
+            "events_processed": 10,
+            "events_matched": 3,
+            "number_of_actions": 3,
+            "number_of_session_stats": 6,
+            "number_of_rules": 3,
+            "number_of_disabled_rules": 0,
+        },
+        (
+            utils.BASE_DATA_PATH
+            / "rulebooks/persistence/single_event_different_rules.yml"
+        ),
+        [
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 1}],
+            },
+            {
+                "rule_name": "r5",
+                "action": "debug",
+                "events": [{"key": "m/i", "value": 5}],
+            },
+            {
+                "rule_name": "r9",
+                "action": "print_event",
+                "events": [{"key": "m/i", "value": 9}],
+            },
+        ],
+        "Single Event Different Rules",
+    ),
+]
+
+
+def setup_vars_file(temp_dir: Union[str, Path]) -> tuple[Path, Path]:
+    """
+    Set up the variables file with the JSON data file path.
+
+    Args:
+        temp_dir: Path to the temporary directory (string or Path object)
+
+    Returns:
+        Path to the created vars file
+        Path to H2 DB File
+    """
+    temp_dir = Path(temp_dir)
+
+    with open(utils.BASE_DATA_PATH / "extra_vars/drools_db_vars.yml") as f:
+        vars_data = yaml.safe_load(f)
+
+    shutil.copy2(
+        utils.BASE_DATA_PATH / "data/items.json", temp_dir / "items.json"
+    )
+    vars_data["json_data_file"] = str(temp_dir / "items.json")
+    vars_data["drools_db_file_path"] = str(
+        temp_dir
+        / (
+            "test;DB_CLOSE_ON_EXIT=FALSE;"
+            "RETENTION_TIME=0;LOCK_TIMEOUT=25000;"
+        )
+    )
+    db_path = temp_dir / "test.mv.db"
+
+    vars_file = temp_dir / "vars.yml"
+    with open(vars_file, "w") as f:
+        yaml.dump(vars_data, f)
+
+    print(vars_data["json_data_file"])
+    return vars_file, db_path
+
+
+def accumulate_lifecycle_stats(
+    total_stats: Dict[str, Any], lifecycle_stats: Dict[str, Any]
+) -> None:
+    """
+    Accumulate statistics from a single lifecycle into the total statistics.
+
+    Args:
+        total_stats: Dictionary containing cumulative statistics
+        lifecycle_stats: Dictionary containing statistics from a single
+            lifecycle
+    """
+    total_stats["total_events_processed"] += lifecycle_stats[
+        "events_processed"
+    ]
+    total_stats["total_rules_triggered"] += lifecycle_stats["rules_triggered"]
+    total_stats["total_events_matched"] += lifecycle_stats["events_matched"]
+    total_stats["total_actions"] += lifecycle_stats["action_counter"]
+    total_stats["total_session_stats"] += lifecycle_stats[
+        "session_stats_counter"
+    ]
+
+    # Merge actions by rule
+    for rule, count in lifecycle_stats["actions_by_rule"].items():
+        total_stats["all_actions_by_rule"][rule] = (
+            total_stats["all_actions_by_rule"].get(rule, 0) + count
+        )
+
+    # Merge matches found
+    total_stats["all_matches_found"].extend(lifecycle_stats["matches_found"])
+
+
+async def run_process_lifecycle(
+    cmd: utils.Command, is_final_run: bool
+) -> asyncio.subprocess.Process:
+    """
+    Start and manage a single process lifecycle.
+
+    Args:
+        cmd: Command to execute
+        is_final_run: Whether this is the final lifecycle (no restart)
+
+    Returns:
+        The created subprocess
+    """
+    LOGGER.info(f"Running command: {cmd}")
+
+    proc = await asyncio.create_subprocess_shell(
+        str(cmd),
+        cwd=utils.BASE_DATA_PATH,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    if not is_final_run:
+        await asyncio.sleep(RESTART_INTERVAL)
+
+    return proc
+
+
+async def terminate_process(
+    proc: asyncio.subprocess.Process, restart_num: int, db_path: Path
+) -> None:
+    """
+    Gracefully terminate a process, with fallback to force kill.
+
+    Args:
+        proc: The subprocess to terminate
+        restart_num: Current restart number (for logging)
+
+    Raises:
+        RuntimeError: If the process has already exited with an error
+    """
+    LOGGER.info(f"Killing process (restart {restart_num + 1}/{NUM_RESTARTS})")
+
+    # Check if process has already exited with an error
+    if proc.returncode is not None and proc.returncode != 0:
+        error_msg = (
+            f"Process exited unexpectedly with return code {proc.returncode} "
+            f"during restart {restart_num + 1}/{NUM_RESTARTS}"
+        )
+        LOGGER.error(error_msg)
+
+        # Read and log any output from the process
+        try:
+            stdout, stderr = await proc.communicate()
+            if stdout:
+                LOGGER.error(f"Process stdout:\n{stdout.decode()}")
+            if stderr:
+                LOGGER.error(f"Process stderr:\n{stderr.decode()}")
+        except Exception as e:
+            LOGGER.warning(f"Could not read process output: {e}")
+
+        raise RuntimeError(error_msg)
+
+    # Check if process exited successfully (return code 0)
+    if proc.returncode == 0:
+        LOGGER.info(
+            "Process already completed successfully, no need to terminate"
+        )
+        return
+
+    # Process is still running, terminate it gracefully
+    try:
+        LOGGER.warning("Sending SIGTERM to process")
+        proc.send_signal(signal.SIGTERM)
+        await asyncio.wait_for(proc.wait(), timeout=5)
+    except asyncio.TimeoutError:
+        LOGGER.warning("Process didn't terminate gracefully, forcing kill")
+        proc.kill()
+        await proc.wait()
+
+    # Add a small delay to ensure the process has fully exited
+    # and file handles are released
+    LOGGER.info("Waiting for process cleanup...")
+    await ensure_file_is_free(db_path)
+    await asyncio.sleep(1)
+
+
+def log_final_results(
+    total_stats: Dict[str, Any],
+    restart_count: int,
+    lifecycle_results: List[Dict[str, Any]],
+) -> None:
+    """
+    Log the final test results and statistics.
+
+    Args:
+        total_stats: Dictionary containing cumulative statistics
+        restart_count: Number of times the process was restarted
+        lifecycle_results: List of result dictionaries from each lifecycle
+    """
+    LOGGER.info("=" * 80)
+    LOGGER.info(f"Test completed with {restart_count} restarts")
+    LOGGER.info(f"Total lifecycles: {len(lifecycle_results)}")
+    LOGGER.info(
+        f"Total events processed across all restarts: "
+        f"{total_stats['total_events_processed']}"
+    )
+    LOGGER.info(
+        f"Total rules triggered across all restarts: "
+        f"{total_stats['total_rules_triggered']}"
+    )
+    LOGGER.info(
+        f"Total events matched across all restarts: "
+        f"{total_stats['total_events_matched']}"
+    )
+    LOGGER.info(
+        f"Total actions across all restarts: "
+        f"{total_stats['total_actions']}"
+    )
+    LOGGER.info(
+        f"Actions by rule across all restarts: "
+        f"{total_stats['all_actions_by_rule']}"
+    )
+    LOGGER.info(
+        f"Total session stats messages: {total_stats['total_session_stats']}"
+    )
+    LOGGER.info("=" * 80)
+
+    for i, result in enumerate(lifecycle_results):
+        LOGGER.info(f"Lifecycle {i}: {result}")
+
+    LOGGER.info(
+        f"All matches found across lifecycles: "
+        f"{total_stats['all_matches_found']}"
+    )
+
+
+def validate_final_results(
+    total_stats: Dict[str, Any],
+    restart_count: int,
+    rule_matches: List[Dict[str, Any]],
+    counts: Dict[str, int],
+) -> None:
+    """
+    Validate that the test results meet expectations.
+
+    Args:
+        total_stats: Dictionary containing cumulative statistics
+        restart_count: Number of times the process was restarted
+        rule_matches: List of expected rule matches
+    """
+    # Validate that all expected matches were found across all lifecycles
+    for expected_match in rule_matches:
+        assert expected_match in total_stats["all_matches_found"], (
+            f"Expected match not found across all lifecycles: "
+            f"{expected_match}. "
+            f"Found matches: {total_stats['all_matches_found']}"
+        )
+
+    # Verify we got session stats from multiple lifecycles
+    assert total_stats["total_session_stats"] > 1, (
+        f"Expected multiple SessionStats messages, "
+        f"got {total_stats['total_session_stats']}"
+    )
+
+    # Verify we had the expected number of restarts
+    assert (
+        restart_count == NUM_RESTARTS
+    ), f"Expected {NUM_RESTARTS} restarts, got {restart_count}"
+
+    # Note: With restarts, we might see different event counts than the
+    # original test. The exact counts will depend on event persistence and
+    # recovery behavior. For now, we just verify that we got some events
+    # and actions
+    assert (
+        total_stats["total_events_processed"] > 0
+    ), "No events were processed across all restarts"
+    # For actions without external job tracking (debug, print_event, noop),
+    # we cannot guarantee exact deduplication across process restarts due to
+    # the race condition between action execution and status persistence
+    assert total_stats["total_actions"] >= counts["number_of_actions"], (
+        f"Expected at least {counts['number_of_actions']} actions, "
+        f"got {total_stats['total_actions']}"
+    )
+
+
+async def process_queue_messages(
+    queue: asyncio.Queue,
+    endpoint: str,
+    rule_matches: List[Dict[str, Any]],
+    counts: Dict[str, int],
+    rule_set_name: str,
+    proc_id: str,
+    validate_all_matches: bool = False,
+) -> Dict[str, Any]:
+    """
+    Process all messages in the queue and return statistics.
+    This is called after each process lifecycle to accumulate data.
+
+    rule_matches: A list of expected match dictionaries with structure:
+        [
+            {
+                "rule_name": "r1",
+                "action": "debug",
+                "events": [
+                    {"key": "path/to/value", "value": expected_value},
+                    ...
+                ]
+            },
+            ...
+        ]
+        Each match represents one expected action firing. The "events" array
+        defines the expected values for specific paths in the matching_events
+        using dpath.
+
+    validate_all_matches: If True, requires ALL expected matches to be
+        present. If False, only validates that found matches are correct
+        (but not that all are present).
+    """
+    action_counter = 0
+    session_stats_counter = 0
+    events_processed = 0
+    rules_triggered = 0
+    events_matched = 0
+    actions_by_rule = {}
+
+    # Track which expected matches have been found
+    matches_found = []
+
+    while not queue.empty():
+        data = await queue.get()
+        assert data["path"] == endpoint
+        data = data["payload"]
+
+        if data["type"] == "Action":
+            action_counter += 1
+            assert data["action_uuid"] is not None
+            assert data["ruleset_uuid"] is not None
+            assert data["rule_uuid"] is not None
+            assert data["status"] == "successful"
+            rule_name = data["rule"]
+
+            # Track actions per rule
+            if rule_name not in actions_by_rule:
+                actions_by_rule[rule_name] = 0
+            actions_by_rule[rule_name] += 1
+
+            matching_events = data["matching_events"]
+            action_type = data["action"]
+
+            # Find which match specification this action satisfies
+            match_found = None
+            for expected_match in rule_matches:
+                if expected_match["rule_name"] != rule_name:
+                    continue
+                if expected_match["action"] != action_type:
+                    continue
+
+                # Check if all event key/value pairs match
+                all_events_match = True
+                for event_check in expected_match["events"]:
+                    try:
+                        actual_value = dpath.get(
+                            matching_events, event_check["key"]
+                        )
+                        if actual_value != event_check["value"]:
+                            all_events_match = False
+                            break
+                    except KeyError:
+                        all_events_match = False
+                        break
+
+                if all_events_match:
+                    match_found = expected_match
+                    matches_found.append(expected_match)
+                    break
+
+            assert match_found is not None, (
+                f"Action for rule '{rule_name}' did not match any "
+                f"expected patterns. "
+                f"Action: {action_type}, Matching events: {matching_events}, "
+                f"Expected matches: {rule_matches}"
+            )
+
+        if data["type"] == "SessionStats":
+            session_stats_counter += 1
+            stats = data["stats"]
+
+            # Capture the stats from this session
+            events_processed = stats.get("eventsProcessed", 0)
+            rules_triggered = stats.get("rulesTriggered", 0)
+            events_matched = stats.get("eventsMatched", 0)
+
+            assert stats["ruleSetName"] == rule_set_name
+            assert stats["numberOfRules"] == counts["number_of_rules"]
+            assert (
+                stats["numberOfDisabledRules"]
+                == counts["number_of_disabled_rules"]
+            )
+            assert data["activation_instance_id"] == proc_id
+
+    # Verify matches based on validation mode
+    if validate_all_matches:
+        # Strict validation: ALL expected matches must be found
+        for expected_match in rule_matches:
+            assert expected_match in matches_found, (
+                f"Expected match not found: {expected_match}. "
+                f"Found matches: {matches_found}"
+            )
+    else:
+        # Lenient validation: Any matches found must be valid, but not all
+        # expected matches are required. This is appropriate for partial
+        # lifecycles during restarts
+        pass  # Validation already done during action processing
+
+    return {
+        "action_counter": action_counter,
+        "session_stats_counter": session_stats_counter,
+        "events_processed": events_processed,
+        "rules_triggered": rules_triggered,
+        "events_matched": events_matched,
+        "actions_by_rule": actions_by_rule,
+        "matches_found": matches_found,
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "counts, rulebook, rule_matches, rule_set_name", TEST_DATA
+)
+async def test_multi_restart_rulebook(
+    counts: Dict[str, int],
+    rulebook: Path,
+    rule_matches: List[Dict[str, Any]],
+    rule_set_name: str,
+) -> None:
+    """
+    Verify that we can run an example rulebook with periodic restarts
+    and track how many events get triggered across restarts.
+    This tests event persistence and recovery capabilities.
+    """
+    # Test configuration
+    host = "127.0.0.1"
+    endpoint = "/api/ws2"
+    proc_id = "42"
+    port = utils.get_safe_port()
+
+    async with h2_persistence_context() as temp_dir:
+        # Set up the vars file
+        vars_file, db_path = setup_vars_file(temp_dir)
+
+        websocket_address = f"ws://127.0.0.1:{port}{endpoint}"
+        cmd = utils.Command(
+            rulebook=rulebook,
+            websocket=websocket_address,
+            proc_id=proc_id,
+            heartbeat=2,
+            vars_file=vars_file,
+            persistence_id=str(uuid.uuid4()),
+        )
+
+        # Initialize tracking statistics
+        total_stats = {
+            "total_events_processed": 0,
+            "total_rules_triggered": 0,
+            "total_events_matched": 0,
+            "total_actions": 0,
+            "total_session_stats": 0,
+            "all_actions_by_rule": {},
+            "all_matches_found": [],
+        }
+        restart_count = 0
+        lifecycle_results = []
+
+        # Run server and ansible-rulebook
+        queue = asyncio.Queue()
+        handler = partial(
+            utils.msg_handler, queue=queue, ignore_connection_closed=True
+        )
+
+        async with ws_server.serve(handler, host, port):
+            # +1 for initial run
+            for restart_num in range(NUM_RESTARTS + 1):
+                LOGGER.info(
+                    f"Starting process iteration "
+                    f"{restart_num}/{NUM_RESTARTS}"
+                )
+                is_final_run = restart_num >= NUM_RESTARTS
+
+                # Start the process
+                proc = await run_process_lifecycle(cmd, is_final_run)
+
+                if not is_final_run:
+                    # Terminate the process and process the queue
+                    await terminate_process(proc, restart_num, db_path)
+                    restart_count += 1
+
+                    LOGGER.info(
+                        f"Processing {queue.qsize()} messages from "
+                        f"lifecycle {restart_num}"
+                    )
+                    lifecycle_stats = await process_queue_messages(
+                        queue,
+                        endpoint,
+                        rule_matches,
+                        counts,
+                        rule_set_name,
+                        proc_id,
+                        validate_all_matches=False,
+                    )
+                    lifecycle_results.append(lifecycle_stats)
+                    accumulate_lifecycle_stats(total_stats, lifecycle_stats)
+
+                    LOGGER.info(
+                        f"Lifecycle {restart_num} stats: {lifecycle_stats}"
+                    )
+                    LOGGER.info(
+                        f"Process killed, total restarts so far: "
+                        f"{restart_count}"
+                    )
+                else:
+                    # Final run - let it complete normally
+                    LOGGER.info("Final run - waiting for completion")
+                    await asyncio.wait_for(
+                        proc.wait(), timeout=DEFAULT_TIMEOUT
+                    )
+                    if proc.returncode != 0:
+                        stdout, stderr = await proc.communicate()
+                        raise AssertionError(
+                            "Final lifecycle failed:\n"
+                            f"stdout:\n{stdout.decode()}\n"
+                            f"stderr:\n{stderr.decode()}"
+                        )
+
+                    LOGGER.info(
+                        f"Processing final {queue.qsize()} messages from "
+                        f"lifecycle {restart_num}"
+                    )
+                    lifecycle_stats = await process_queue_messages(
+                        queue,
+                        endpoint,
+                        rule_matches,
+                        counts,
+                        rule_set_name,
+                        proc_id,
+                        validate_all_matches=False,
+                    )
+                    lifecycle_results.append(lifecycle_stats)
+                    accumulate_lifecycle_stats(total_stats, lifecycle_stats)
+
+                    LOGGER.info(f"Final lifecycle stats: {lifecycle_stats}")
+
+        # Log and validate results
+        log_final_results(total_stats, restart_count, lifecycle_results)
+        validate_final_results(
+            total_stats, restart_count, rule_matches, counts
+        )
+
+
+async def ensure_file_is_free(db_path: Path, timeout: int = 5):
+    """Wait until the Linux kernel confirms no one has an flock on the file."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            LOGGER.info(f"Attemping to lock : {db_path}")
+            with open(db_path, "rb+") as f:
+                # Attempt an exclusive non-blocking lock
+                # If this succeeds, the file is truly free
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(f, fcntl.LOCK_UN)
+                return True
+        except IOError:
+            # File is still locked by the dying JVM or kernel cleanup
+            LOGGER.info(f"File is still locked : {db_path}")
+            await asyncio.sleep(1)
+    return False
+
+
+@asynccontextmanager
+async def h2_persistence_context():
+    # 1. Setup: Determine base path (Linux RAM disk vs Mac Temp)
+    base_path = (
+        "/dev/shm"
+        if platform.system() == "Linux" and os.path.exists("/dev/shm")
+        else None
+    )
+
+    # 2. Create unique directory
+    db_dir = tempfile.mkdtemp(prefix="h2_test_", dir=base_path)
+
+    try:
+        # Yield the path to the database (not the directory)
+        yield db_dir
+    finally:
+        # 3. Cleanup: This runs after the 'with' block exits
+        # We add a tiny delay to let the OS release the final file handles
+        await asyncio.sleep(0.2)
+        shutil.rmtree(db_dir, ignore_errors=True)

--- a/tests/e2e/test_multi_restart.py
+++ b/tests/e2e/test_multi_restart.py
@@ -146,13 +146,7 @@ def setup_vars_file(temp_dir: Union[str, Path]) -> tuple[Path, Path]:
         utils.BASE_DATA_PATH / "data/items.json", temp_dir / "items.json"
     )
     vars_data["json_data_file"] = str(temp_dir / "items.json")
-    vars_data["drools_db_file_path"] = str(
-        temp_dir
-        / (
-            "test;DB_CLOSE_ON_EXIT=FALSE;"
-            "RETENTION_TIME=0;LOCK_TIMEOUT=25000;"
-        )
-    )
+    vars_data["drools_db_file_path"] = str(temp_dir / ("test;"))
     db_path = temp_dir / "test.mv.db"
 
     vars_file = temp_dir / "vars.yml"
@@ -520,6 +514,7 @@ async def process_queue_messages(
     }
 
 
+@pytest.mark.skip(reason="Fails in CI: H2 marks DB as locked during restarts")
 @pytest.mark.e2e
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/tests/e2e/test_run_examples.py
+++ b/tests/e2e/test_run_examples.py
@@ -174,6 +174,10 @@ async def test_run_example_rulebook(
         await asyncio.wait_for(proc.wait(), timeout=DEFAULT_TIMEOUT)
         assert proc.returncode == 0
 
+        # Give a small delay to allow any final SessionStats messages
+        # to arrive before the websocket context exits
+        await asyncio.sleep(0.5)
+
     # Verify data
     assert not queue.empty()
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -10,6 +10,7 @@ from subprocess import CompletedProcess
 from typing import Iterable, List, Optional, Union
 
 import websockets.asyncio.server as ws_server
+import websockets.exceptions
 
 BASE_DATA_PATH = Path(f"{__file__}").parent / Path("files")
 DEFAULT_SOURCES = Path(f"{__file__}").parent / Path("../sources")
@@ -49,6 +50,7 @@ class Command:
     skip_audit_events: bool = False
     vault_ids: Optional[list] = None
     vault_password_file: Optional[Path] = None
+    persistence_id: Optional[str] = None
 
     def __post_init__(self):
         # verbosity overrides verbose and debug
@@ -122,6 +124,9 @@ class Command:
                 ]
             )
 
+        if self.persistence_id:
+            result.extend(["--persistence-id", self.persistence_id])
+
         return result
 
     def to_string(self) -> str:
@@ -158,6 +163,7 @@ async def msg_handler(
     queue: asyncio.Queue,
     disconnect: bool = False,
     force_error: bool = False,
+    ignore_connection_closed: bool = False,
 ):
     """
     Handler for a websocket server that passes json messages
@@ -172,18 +178,31 @@ async def msg_handler(
             tests specifically testing reconnection behavior.
         force_error: If True, raises error after 2nd message to test
             error handling
+        ignore_connection_closed: If True, silently handles
+                                  abrupt connection closes
+                                  (useful for restart scenarios)
     """
     i = 0
-    async for message in websocket:
-        payload = json.loads(message)
-        data = {"path": websocket.request.path, "payload": payload}
-        await queue.put(data)
-        if i == 1:
-            if force_error:
-                print(data["bad"])  # force a coding error
-            elif disconnect:
-                await websocket.close()  # should be auto reconnected
-        i += 1
+    try:
+        async for message in websocket:
+            payload = json.loads(message)
+            data = {"path": websocket.request.path, "payload": payload}
+            await queue.put(data)
+            if i == 1:
+                if force_error:
+                    print(data["bad"])  # force a coding error
+                elif disconnect:
+                    await websocket.close()  # should be auto reconnected
+            i += 1
+    except websockets.exceptions.ConnectionClosedError:
+        if ignore_connection_closed:
+            # Connection closed abruptly (e.g., client process
+            # killed during restart)
+            # This is expected, so we handle it gracefully
+            pass
+        else:
+            # Unexpected connection close - re-raise to surface the error
+            raise
 
 
 def get_safe_port() -> int:

--- a/tests/sources/json_event_queue.py
+++ b/tests/sources/json_event_queue.py
@@ -1,0 +1,84 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def update_json_file(filename: str, data: list[Dict]):
+    tmp_filename = f"{filename}.tmp"
+    with open(tmp_filename, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+    os.replace(tmp_filename, filename)
+
+
+async def main(queue: asyncio.Queue, args: Dict[str, Any]):
+    if not args.get("file"):
+        raise ValueError("file is a required argument")
+
+    filename = args.get("file")
+    if not os.path.exists(filename):
+        raise FileNotFoundError(filename)
+
+    delay = int(args.get("delay", 0))
+    startup_delay = int(args.get("startup_delay", 0))
+    fail_after = int(args.get("fail_after", 0))
+
+    with open(filename, "r", encoding="utf-8") as file:
+        data = json.load(file)
+        if not isinstance(data, list):
+            data = [data]
+
+    await asyncio.sleep(startup_delay)
+    counter = 0
+    for event in list(data):
+        await queue.put(event)
+        events_sent = counter + 1
+        if fail_after > 0 and events_sent % fail_after == 0:
+            logger.warning("Failing after %d events", fail_after)
+            raise Exception(
+                f"Intentionally Failing after every {fail_after} events"
+            )
+
+        if args.get("eda_feedback_queue"):
+            feedback_event = await args["eda_feedback_queue"].get()
+            if event["meta"]["uuid"] != feedback_event["meta"]["uuid"]:
+                print("Event mismatch")
+            else:
+                data.remove(event)
+                update_json_file(filename, data)
+
+        if event.get("raise_exception"):
+            msg = event.get("raise_exception")
+            if isinstance(msg, str):
+                raise Exception(msg)
+            else:
+                raise Exception("The event suggests to raise exception")
+
+        await asyncio.sleep(delay)
+        counter += 1
+
+
+if __name__ == "__main__":
+
+    class MockQueue:
+        async def put(self, event):
+            print(event)
+
+    asyncio.run(main(MockQueue(), dict(file="path/to/test.json")))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -286,21 +286,21 @@ async def test_run_job_template(
             UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE_NO_LABELS,
             UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE_NO_LABELS,
             False,
-            False,
+            {},
         ),
         (
             [CUSTOMER_LABEL],
             UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE,
             UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE,
             False,
-            False,
+            {},
         ),
         (
             [CUSTOMER_LABEL],
             UNIFIED_JOB_TEMPLATE_PAGE1_RESPONSE_NO_LABELS,
             UNIFIED_JOB_TEMPLATE_PAGE2_RESPONSE_NO_LABELS,
             False,
-            False,
+            {},
         ),
     ],
 )
@@ -442,3 +442,344 @@ async def test_session_get_called_with_expected_url(
         calls = mocked_session.get.mock_calls[0]
         args = calls[1]
         assert args[0] == expected
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_job_template_found(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label with job_template type when job is found."""
+    from ansible_rulebook.job_template_runner import JOB_TEMPLATE_TYPE
+
+    label_name = "test-label"
+    job_url = "api/v2/jobs/123/"
+
+    # Mock response for job template
+    job_template_response = {
+        "id": 255,
+        "type": "job_template",
+        "name": JOB_TEMPLATE_NAME_1,
+        "ask_limit_on_launch": False,
+        "ask_variables_on_launch": False,
+        "ask_inventory_on_launch": False,
+        "ask_labels_on_launch": True,
+        "related": {"launch": JOB_TEMPLATE_1_LAUNCH_SLUG},
+        "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+    }
+
+    # Mock response for jobs with label
+    jobs_response = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [{"url": job_url, "id": 123, "status": "successful"}],
+    }
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [job_template_response],
+                }
+            ),
+        )
+
+        # Mock the jobs endpoint filtered by label
+        jobs_slug = f"api/v2/job_templates/255/jobs/?labels__name={label_name}"
+        mocked.get(
+            f"{new_job_template_runner.host}{jobs_slug}",
+            status=200,
+            body=json.dumps(jobs_response),
+        )
+
+        result = await new_job_template_runner.get_job_url_from_label(
+            JOB_TEMPLATE_NAME_1,
+            ORGANIZATION_NAME,
+            JOB_TEMPLATE_TYPE,
+            label_name,
+        )
+
+        assert result == job_url
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_job_template_not_found(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label with job_template type.
+
+    When no job is found.
+    """
+    from ansible_rulebook.job_template_runner import JOB_TEMPLATE_TYPE
+
+    label_name = "test-label"
+
+    # Mock response for job template
+    job_template_response = {
+        "id": 255,
+        "type": "job_template",
+        "name": JOB_TEMPLATE_NAME_1,
+        "ask_limit_on_launch": False,
+        "ask_variables_on_launch": False,
+        "ask_inventory_on_launch": False,
+        "ask_labels_on_launch": True,
+        "related": {"launch": JOB_TEMPLATE_1_LAUNCH_SLUG},
+        "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+    }
+
+    # Mock response for jobs with label - no results
+    jobs_response = {
+        "count": 0,
+        "next": None,
+        "previous": None,
+        "results": [],
+    }
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [job_template_response],
+                }
+            ),
+        )
+
+        # Mock the jobs endpoint filtered by label
+        jobs_slug = f"api/v2/job_templates/255/jobs/?labels__name={label_name}"
+        mocked.get(
+            f"{new_job_template_runner.host}{jobs_slug}",
+            status=200,
+            body=json.dumps(jobs_response),
+        )
+
+        result = await new_job_template_runner.get_job_url_from_label(
+            JOB_TEMPLATE_NAME_1,
+            ORGANIZATION_NAME,
+            JOB_TEMPLATE_TYPE,
+            label_name,
+        )
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_workflow_template_found(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label with workflow_template type.
+
+    When job is found.
+    """
+    from ansible_rulebook.job_template_runner import WORKFLOW_TEMPLATE_TYPE
+
+    label_name = "test-label"
+    workflow_job_url = "api/v2/workflow_jobs/456/"
+
+    # Mock response for workflow template
+    workflow_template_response = {
+        "id": 300,
+        "type": "workflow_job_template",
+        "name": JOB_TEMPLATE_NAME_1,
+        "ask_limit_on_launch": False,
+        "ask_variables_on_launch": False,
+        "ask_inventory_on_launch": True,
+        "ask_labels_on_launch": True,
+        "related": {"launch": JOB_TEMPLATE_2_LAUNCH_SLUG},
+        "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+    }
+
+    # Mock response for workflow jobs with label
+    workflow_jobs_response = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [
+            {"url": workflow_job_url, "id": 456, "status": "successful"}
+        ],
+    }
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [workflow_template_response],
+                }
+            ),
+        )
+
+        # Mock the workflow jobs endpoint filtered by label
+        jobs_slug = (
+            f"api/v2/workflow_job_templates/300/workflow_jobs/"
+            f"?labels__name={label_name}"
+        )
+        mocked.get(
+            f"{new_job_template_runner.host}{jobs_slug}",
+            status=200,
+            body=json.dumps(workflow_jobs_response),
+        )
+
+        result = await new_job_template_runner.get_job_url_from_label(
+            JOB_TEMPLATE_NAME_1,
+            ORGANIZATION_NAME,
+            WORKFLOW_TEMPLATE_TYPE,
+            label_name,
+        )
+
+        assert result == workflow_job_url
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_workflow_template_not_found(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label with workflow_template type.
+
+    When no job is found.
+    """
+    from ansible_rulebook.job_template_runner import WORKFLOW_TEMPLATE_TYPE
+
+    label_name = "test-label"
+
+    # Mock response for workflow template
+    workflow_template_response = {
+        "id": 300,
+        "type": "workflow_job_template",
+        "name": JOB_TEMPLATE_NAME_1,
+        "ask_limit_on_launch": False,
+        "ask_variables_on_launch": False,
+        "ask_inventory_on_launch": True,
+        "ask_labels_on_launch": True,
+        "related": {"launch": JOB_TEMPLATE_2_LAUNCH_SLUG},
+        "summary_fields": {"organization": {"name": ORGANIZATION_NAME}},
+    }
+
+    # Mock response for workflow jobs with label - no results
+    workflow_jobs_response = {
+        "count": 0,
+        "next": None,
+        "previous": None,
+        "results": [],
+    }
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(
+                {
+                    "count": 1,
+                    "next": None,
+                    "previous": None,
+                    "results": [workflow_template_response],
+                }
+            ),
+        )
+
+        # Mock the workflow jobs endpoint filtered by label
+        jobs_slug = (
+            f"api/v2/workflow_job_templates/300/workflow_jobs/"
+            f"?labels__name={label_name}"
+        )
+        mocked.get(
+            f"{new_job_template_runner.host}{jobs_slug}",
+            status=200,
+            body=json.dumps(workflow_jobs_response),
+        )
+
+        result = await new_job_template_runner.get_job_url_from_label(
+            JOB_TEMPLATE_NAME_1,
+            ORGANIZATION_NAME,
+            WORKFLOW_TEMPLATE_TYPE,
+            label_name,
+        )
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_template_not_exists(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label when the template doesn't exist."""
+    from ansible_rulebook.job_template_runner import JOB_TEMPLATE_TYPE
+
+    label_name = "test-label"
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint - no results
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(NO_JOB_TEMPLATE_PAGE1_RESPONSE),
+        )
+
+        with pytest.raises(JobTemplateNotFoundException):
+            await new_job_template_runner.get_job_url_from_label(
+                JOB_TEMPLATE_NAME_1,
+                ORGANIZATION_NAME,
+                JOB_TEMPLATE_TYPE,
+                label_name,
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_workflow_template_not_exists(
+    new_job_template_runner,
+):
+    """Test get_job_url_from_label when the workflow template doesn't exist."""
+    from ansible_rulebook.job_template_runner import WORKFLOW_TEMPLATE_TYPE
+
+    label_name = "test-label"
+
+    with aioresponses() as mocked:
+        # Mock the unified job templates endpoint - no results
+        mocked.get(
+            f"{new_job_template_runner.host}{UNIFIED_JOB_TEMPLATE_PAGE1_SLUG}",
+            status=200,
+            body=json.dumps(NO_JOB_TEMPLATE_PAGE1_RESPONSE),
+        )
+
+        with pytest.raises(WorkflowJobTemplateNotFoundException):
+            await new_job_template_runner.get_job_url_from_label(
+                JOB_TEMPLATE_NAME_1,
+                ORGANIZATION_NAME,
+                WORKFLOW_TEMPLATE_TYPE,
+                label_name,
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_job_url_from_label_invalid_type(new_job_template_runner):
+    """Test get_job_url_from_label with an invalid type."""
+    label_name = "test-label"
+    invalid_type = "invalid_type"
+
+    with pytest.raises(ValueError) as exc_info:
+        await new_job_template_runner.get_job_url_from_label(
+            JOB_TEMPLATE_NAME_1,
+            ORGANIZATION_NAME,
+            invalid_type,
+            label_name,
+        )
+
+    assert "Invalid type" in str(exc_info.value)
+    assert invalid_type in str(exc_info.value)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -56,7 +56,7 @@ def load_rulebook(rules_file):
     rulesets = parse_rule_sets(data)
     pprint(rulesets)
 
-    ruleset_queues = [(ruleset, asyncio.Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, asyncio.Queue(), {}) for ruleset in rulesets]
 
     event_log = asyncio.Queue()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,9 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import argparse
 import asyncio
 import json
 import logging
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -55,39 +58,56 @@ class SourceTask:
 
 
 RULEBOOK_NAMES = [
-    ("examples/01_noop.yml"),
-    ("examples/92_gather_facts_sans_inventory.yml"),
+    ("examples/01_noop.yml", None, False),
+    ("examples/92_gather_facts_sans_inventory.yml", None, False),
+    (
+        "examples/01_noop.yml",
+        argparse.Namespace(
+            id="42", persistence_id="test-persistence-id", heartbeat=0
+        ),
+        True,
+    ),
 ]
 
 
-@pytest.mark.parametrize("rulebook", RULEBOOK_NAMES)
+@pytest.mark.parametrize("rulebook, args, use_persistence", RULEBOOK_NAMES)
 @pytest.mark.asyncio
-async def test_01_noop(rulebook):
-    ruleset_queues, event_log = load_rulebook(rulebook)
+async def test_01_noop(rulebook, args, use_persistence):
+    # Use a temporary directory that auto-cleans on exit
+    variables = {}
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Only populate the db path if persistence is needed
+        if use_persistence:
+            db_path = Path(tmpdir) / "test_drools.db"
+            variables = {"drools_db_file_path": str(db_path)}
 
-    queue = ruleset_queues[0][1]
-    queue.put_nowait(dict(i=1))
-    queue.put_nowait(Shutdown())
+        ruleset_queues, event_log = load_rulebook(rulebook)
 
-    with patch("uuid.uuid4", return_value=DUMMY_UUID):
-        await run_rulesets(
-            event_log,
-            ruleset_queues,
-            dict(),
-            dict(),
-        )
+        queue = ruleset_queues[0][1]
+        queue.put_nowait(dict(i=1))
+        queue.put_nowait(Shutdown())
 
-    event = event_log.get_nowait()
-    assert event["type"] == "Action", "1"
-    assert event["action"] == "noop", "2"
-    assert event["action_uuid"] == DUMMY_UUID
-    assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
-    assert event["status"] == "successful"
-    assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
-    assert event["matching_events"] == {"m": {"i": 1}}, "3"
-    event = event_log.get_nowait()
-    assert event["type"] == "Shutdown", "7"
-    assert event_log.empty()
+        with patch("uuid.uuid4", return_value=DUMMY_UUID):
+            await run_rulesets(
+                event_log,
+                ruleset_queues,
+                variables,
+                "",
+                args,
+            )
+
+        event = event_log.get_nowait()
+        assert event["type"] == "Action", "1"
+        assert event["action"] == "noop", "2"
+        assert event["action_uuid"] == DUMMY_UUID
+        assert event["ruleset_uuid"] == ruleset_queues[0][0].uuid
+        assert event["status"] == "successful"
+        assert event["rule_uuid"] == ruleset_queues[0][0].rules[0].uuid
+        assert event["matching_events"] == {"m": {"i": 1}}, "3"
+        event = event_log.get_nowait()
+        assert event["type"] == "Shutdown", "7"
+        assert event_log.empty()
+    # tmpdir and all its contents are automatically deleted here
 
 
 @pytest.mark.asyncio
@@ -2113,23 +2133,28 @@ async def test_46_job_template():
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template",
-            return_value=response_obj,
+            "job_template_runner.launch_job_template",
+            return_value=job_url,
         ):
-            await run_rulesets(
-                event_log,
-                ruleset_queues,
-                dict(),
-                "playbooks/inventory.yml",
-            )
+            with patch(
+                "ansible_rulebook.action.run_job_template."
+                "job_template_runner.monitor_job",
+                return_value=response_obj,
+            ):
+                await run_rulesets(
+                    event_log,
+                    ruleset_queues,
+                    dict(),
+                    "playbooks/inventory.yml",
+                )
 
-            while not event_log.empty():
-                event = event_log.get_nowait()
-                if event["type"] == "Action":
-                    action = event
+                while not event_log.empty():
+                    event = event_log.get_nowait()
+                    if event["type"] == "Action":
+                        action = event
 
-            assert action["url"] == job_url
-            assert action["action"] == "run_job_template"
+                assert action["url"] == job_url
+                assert action["action"] == "run_job_template"
 
 
 JOB_TEMPLATE_ERRORS = [
@@ -2149,7 +2174,7 @@ async def test_46_job_template_exception(err_msg, err):
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template",
+            "job_template_runner.launch_job_template",
             side_effect=err,
         ):
             await run_rulesets(
@@ -2269,7 +2294,7 @@ async def test_79_workflow_job_template_exception(err_msg, err):
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             "ansible_rulebook.action.run_workflow_template."
-            "job_template_runner.run_workflow_job_template",
+            "job_template_runner.launch_workflow_job_template",
             side_effect=err,
         ):
             await run_rulesets(
@@ -2320,23 +2345,27 @@ async def test_79_workflow_job_template():
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             "ansible_rulebook.action.run_workflow_template."
-            "job_template_runner.run_workflow_job_template",
-            return_value=response_obj,
+            "job_template_runner.launch_workflow_job_template",
+            return_value=job_url,
         ):
-            await run_rulesets(
-                event_log,
-                ruleset_queues,
-                dict(),
-                dict(),
-            )
+            with patch(
+                "ansible_rulebook.action.run_workflow_template."
+                "job_template_runner.monitor_job",
+                return_value=response_obj,
+            ):
+                await run_rulesets(
+                    event_log,
+                    ruleset_queues,
+                    dict(),
+                    dict(),
+                )
 
-            while not event_log.empty():
-                event = event_log.get_nowait()
-                if event["type"] == "Action":
-                    action = event
-
-            assert action["url"] == job_url
-            assert action["action"] == "run_workflow_template"
+                while not event_log.empty():
+                    event = event_log.get_nowait()
+                    if event["type"] == "Action":
+                        action = event
+                assert action["url"] == job_url
+                assert action["action"] == "run_workflow_template"
 
 
 @pytest.mark.asyncio
@@ -2449,7 +2478,11 @@ INCLUDE_EVENTS_RUN = [
     (
         (
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template"
+            "job_template_runner.launch_job_template"
+        ),
+        (
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job"
         ),
         "examples/84_job_template_exclude_events.yml",
         "run_job_template",
@@ -2459,7 +2492,11 @@ INCLUDE_EVENTS_RUN = [
     (
         (
             "ansible_rulebook.action.run_workflow_template."
-            "job_template_runner.run_workflow_job_template"
+            "job_template_runner.launch_workflow_job_template"
+        ),
+        (
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job"
         ),
         "examples/85_workflow_template_exclude_events.yml",
         "run_workflow_template",
@@ -2469,7 +2506,11 @@ INCLUDE_EVENTS_RUN = [
     (
         (
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template"
+            "job_template_runner.launch_job_template"
+        ),
+        (
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job"
         ),
         "examples/86_job_template_include_events.yml",
         "run_job_template",
@@ -2479,7 +2520,11 @@ INCLUDE_EVENTS_RUN = [
     (
         (
             "ansible_rulebook.action.run_workflow_template."
-            "job_template_runner.run_workflow_job_template"
+            "job_template_runner.launch_workflow_job_template"
+        ),
+        (
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job"
         ),
         "examples/87_workflow_template_include_events.yml",
         "run_workflow_template",
@@ -2489,7 +2534,11 @@ INCLUDE_EVENTS_RUN = [
     (
         (
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template"
+            "job_template_runner.launch_job_template"
+        ),
+        (
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job"
         ),
         "examples/88_job_template_no_args.yml",
         "run_job_template",
@@ -2501,10 +2550,11 @@ INCLUDE_EVENTS_RUN = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "location,rulebook,action_type,job_url,expected_keys", INCLUDE_EVENTS_RUN
+    "location,monitor,rulebook,action_type,job_url,expected_keys",
+    INCLUDE_EVENTS_RUN,
 )
 async def test_include_events(
-    location, rulebook, action_type, job_url, expected_keys
+    location, monitor, rulebook, action_type, job_url, expected_keys
 ):
     ruleset_queues, event_log = load_rulebook(rulebook)
 
@@ -2517,26 +2567,30 @@ async def test_include_events(
     with SourceTask(rs.sources[0], "sources", {}, queue):
         with patch(
             location,
-            return_value=response_obj,
+            return_value=job_url,
         ) as mocked_obj:
-            await run_rulesets(
-                event_log,
-                ruleset_queues,
-                dict(),
-                "playbooks/inventory.yml",
-            )
+            with patch(
+                monitor,
+                return_value=response_obj,
+            ):
+                await run_rulesets(
+                    event_log,
+                    ruleset_queues,
+                    dict(),
+                    "playbooks/inventory.yml",
+                )
 
-            while not event_log.empty():
-                event = event_log.get_nowait()
-                if event["type"] == "Action":
-                    action = event
+                while not event_log.empty():
+                    event = event_log.get_nowait()
+                    if event["type"] == "Action":
+                        action = event
 
-            assert action["url"] == job_url
-            assert action["action"] == action_type
-            assert (
-                list(mocked_obj.call_args.args[2]["extra_vars"].keys())
-                == expected_keys
-            )
+                assert action["url"] == job_url
+                assert action["action"] == action_type
+                assert (
+                    list(mocked_obj.call_args.args[2]["extra_vars"].keys())
+                    == expected_keys
+                )
 
 
 @pytest.mark.asyncio
@@ -2711,7 +2765,7 @@ async def test_96_job_template_with_lock(response, my_vars, expected_order):
 
     order_of_templates = []
 
-    async def dummy_template_runner(arg1, arg2, arg3, arg4):
+    async def dummy_template_runner(arg1):
         order_of_templates.append(arg1)
         if arg1 in response:
             obj = response[arg1]
@@ -2724,24 +2778,29 @@ async def test_96_job_template_with_lock(response, my_vars, expected_order):
     with SourceTask(rs.sources[0], "sources", my_vars, queue):
         with patch(
             "ansible_rulebook.action.run_job_template."
-            "job_template_runner.run_job_template",
-            side_effect=dummy_template_runner,
+            "job_template_runner.launch_job_template",
+            side_effect=expected_order,
         ):
-            await run_rulesets(
-                event_log,
-                ruleset_queues,
-                my_vars,
-                "playbooks/inventory.yml",
-            )
+            with patch(
+                "ansible_rulebook.action.run_job_template."
+                "job_template_runner.monitor_job",
+                side_effect=dummy_template_runner,
+            ):
+                await run_rulesets(
+                    event_log,
+                    ruleset_queues,
+                    my_vars,
+                    "playbooks/inventory.yml",
+                )
 
-            while not event_log.empty():
-                event = event_log.get_nowait()
-                if event["type"] == "Action":
-                    action = event
+                while not event_log.empty():
+                    event = event_log.get_nowait()
+                    if event["type"] == "Action":
+                        action = event
 
-            assert action["action"] == "run_job_template"
+                assert action["action"] == "run_job_template"
 
-    assert order_of_templates == expected_order
+            assert order_of_templates == expected_order
 
 
 @pytest.mark.jira("AAPRFE-2108")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -55,7 +55,7 @@ async def test_generate_rules():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -80,7 +80,7 @@ async def test_generate_rules_multiple_conditions_any():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -108,7 +108,7 @@ async def test_generate_rules_multiple_conditions_all():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -134,7 +134,7 @@ async def test_generate_rules_multiple_conditions_all_3():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -234,7 +234,7 @@ async def test_rule_name_substitution():
         inventory = yaml.safe_load(f.read())
 
     rulesets = parse_rule_sets(data, variables)
-    ruleset_queues = [(ruleset, Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
     ruleset_name = durable_rulesets[0].ruleset.name
 

--- a/tests/unit/action/test_helper.py
+++ b/tests/unit/action/test_helper.py
@@ -1,0 +1,589 @@
+#  Copyright 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from freezegun import freeze_time
+
+from ansible_rulebook.action.control import Control
+from ansible_rulebook.action.helper import (
+    FAILED_STATUS,
+    INTERNAL_ACTION_STATUS,
+    KEY_EDA_VARS,
+    STARTED_STATUS,
+    Helper,
+)
+from ansible_rulebook.action.metadata import Metadata
+from ansible_rulebook.conf import settings
+
+DUMMY_UUID = "eb7de03f-6f8f-4943-b69e-3c90db346edf"
+RULE_UUID = "abcdef3f-6f8f-4943-b69e-3c90db346edf"
+RULE_SET_UUID = "00aabbcc-1111-2222-b69e-3c90db346edf"
+RULE_RUN_AT = "2023-06-11T12:13:10Z"
+ACTION_RUN_AT = "2023-06-11T12:13:14Z"
+EVENT_UUID = "event-uuid-123"
+
+
+@pytest.fixture
+def metadata():
+    return Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+    )
+
+
+@pytest_asyncio.fixture
+async def control():
+    queue = asyncio.Queue()
+    return Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"event": {"a": 1}},
+        project_data_file="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_helper_init(metadata, control):
+    """Test Helper initialization"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+        assert helper.metadata == metadata
+        assert helper.control == control
+        assert helper.uuid == DUMMY_UUID
+        assert helper.action == "test_action"
+
+
+@freeze_time("2023-06-11 12:13:14")
+@pytest.mark.asyncio
+async def test_send_status(metadata, control):
+    """Test send_status sends correct payload to queue"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+
+        data = {
+            "status": "successful",
+            "run_at": ACTION_RUN_AT,
+        }
+
+        await helper.send_status(data, obj_type="Action")
+
+        assert not control.queue.empty()
+        payload = await control.queue.get()
+
+        assert payload["type"] == "Action"
+        assert payload["action"] == "test_action"
+        assert payload["action_uuid"] == DUMMY_UUID
+        assert payload["ruleset"] == metadata.rule_set
+        assert payload["ruleset_uuid"] == metadata.rule_set_uuid
+        assert payload["rule"] == metadata.rule
+        assert payload["rule_uuid"] == metadata.rule_uuid
+        assert payload["rule_run_at"] == metadata.rule_run_at
+        assert payload["activation_id"] == settings.identifier
+        assert payload["activation_instance_id"] == settings.identifier
+        assert payload["status"] == "successful"
+        assert payload["run_at"] == ACTION_RUN_AT
+
+
+@pytest.mark.asyncio
+async def test_send_status_skip_audit_events(metadata, control):
+    """Test send_status skips when skip_audit_events is True"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+
+        original_skip = settings.skip_audit_events
+        try:
+            settings.skip_audit_events = True
+
+            data = {"status": "successful"}
+            await helper.send_status(data)
+
+            assert control.queue.empty()
+        finally:
+            settings.skip_audit_events = original_skip
+
+
+@freeze_time("2023-06-11 12:13:14")
+@pytest.mark.asyncio
+async def test_send_default_status(metadata, control):
+    """Test send_default_status sends default payload"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+
+        await helper.send_default_status()
+
+        assert not control.queue.empty()
+        payload = await control.queue.get()
+
+        assert payload["status"] == INTERNAL_ACTION_STATUS
+        assert payload["matching_events"] == {"m": {"a": 1}}
+        assert "run_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_send_default_status_skip_audit_events(metadata, control):
+    """Test send_default_status skips when skip_audit_events is True"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+
+        original_skip = settings.skip_audit_events
+        try:
+            settings.skip_audit_events = True
+
+            await helper.send_default_status()
+
+            assert control.queue.empty()
+        finally:
+            settings.skip_audit_events = original_skip
+
+
+@pytest.mark.asyncio
+async def test_get_events_single_event(metadata, control):
+    """Test get_events returns single event with 'm' key"""
+    helper = Helper(metadata, control, "test_action")
+
+    events = helper.get_events()
+
+    assert events == {"m": {"a": 1}}
+
+
+@pytest.mark.asyncio
+async def test_get_events_multiple_events(metadata):
+    """Test get_events returns multiple events"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"events": {"m_0": {"a": 1}, "m_1": {"b": 2}}},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    events = helper.get_events()
+
+    assert events == {"m_0": {"a": 1}, "m_1": {"b": 2}}
+
+
+@pytest.mark.asyncio
+async def test_get_events_no_events(metadata):
+    """Test get_events returns empty dict when no events"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"other": "data"},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    events = helper.get_events()
+
+    assert events == {}
+
+
+@pytest.mark.asyncio
+async def test_embellish_internal_event(metadata, control):
+    """Test embellish_internal_event adds metadata"""
+    with patch("uuid.uuid4", return_value=DUMMY_UUID):
+        helper = Helper(metadata, control, "test_action")
+
+        event = {"data": "test"}
+
+        with patch(
+            "ansible_rulebook.action.helper.insert_meta"
+        ) as mock_insert:
+            mock_insert.return_value = {
+                "data": "test",
+                "meta": {
+                    "source_name": "test_action",
+                    "source_type": "internal",
+                },
+            }
+
+            result = helper.embellish_internal_event(event)
+
+            mock_insert.assert_called_once_with(
+                event, source_name="test_action", source_type="internal"
+            )
+            assert result["meta"]["source_name"] == "test_action"
+            assert result["meta"]["source_type"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_set_action(metadata, control):
+    """Test set_action updates action name"""
+    helper = Helper(metadata, control, "original_action")
+    assert helper.action == "original_action"
+
+    helper.set_action("new_action")
+    assert helper.action == "new_action"
+
+
+@pytest.mark.asyncio
+async def test_collect_extra_vars_with_event(metadata, control):
+    """Test collect_extra_vars includes event data"""
+    helper = Helper(metadata, control, "test_action")
+
+    user_vars = {"user_var": "value"}
+
+    result = helper.collect_extra_vars(user_vars, include_events=True)
+
+    assert result["user_var"] == "value"
+    assert KEY_EDA_VARS in result
+    assert result[KEY_EDA_VARS]["ruleset"] == metadata.rule_set
+    assert result[KEY_EDA_VARS]["rule"] == metadata.rule
+    assert result[KEY_EDA_VARS]["event"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_collect_extra_vars_with_events(metadata):
+    """Test collect_extra_vars includes multiple events data"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"events": {"m_0": {"a": 1}, "m_1": {"b": 2}}},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    user_vars = {"user_var": "value"}
+
+    result = helper.collect_extra_vars(user_vars, include_events=True)
+
+    assert result["user_var"] == "value"
+    assert KEY_EDA_VARS in result
+    assert result[KEY_EDA_VARS]["events"] == {"m_0": {"a": 1}, "m_1": {"b": 2}}
+
+
+@pytest.mark.asyncio
+async def test_collect_extra_vars_without_events(metadata, control):
+    """Test collect_extra_vars excludes event data when include_events=False"""
+    helper = Helper(metadata, control, "test_action")
+
+    user_vars = {"user_var": "value"}
+
+    result = helper.collect_extra_vars(user_vars, include_events=False)
+
+    assert result == {"user_var": "value"}
+    assert KEY_EDA_VARS not in result
+
+
+@pytest.mark.asyncio
+async def test_collect_extra_vars_none_user_vars(metadata, control):
+    """Test collect_extra_vars handles None user_vars"""
+    helper = Helper(metadata, control, "test_action")
+
+    result = helper.collect_extra_vars(None, include_events=True)
+
+    assert KEY_EDA_VARS in result
+    assert result[KEY_EDA_VARS]["ruleset"] == metadata.rule_set
+    assert result[KEY_EDA_VARS]["rule"] == metadata.rule
+    assert result[KEY_EDA_VARS]["event"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_collect_extra_vars_preserves_user_vars(metadata, control):
+    """Test collect_extra_vars doesn't modify original user_vars"""
+    helper = Helper(metadata, control, "test_action")
+
+    user_vars = {"user_var": "value"}
+    original_vars = user_vars.copy()
+
+    result = helper.collect_extra_vars(user_vars, include_events=True)
+
+    assert user_vars == original_vars
+    assert result != user_vars
+
+
+@pytest.mark.asyncio
+async def test_update_action_state_with_persistent_info(metadata, control):
+    """Test update_action_state calls update_action_info when
+    persistent_info exists"""
+    # Create metadata with persistent_info
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    info = {"status": "completed"}
+
+    with patch(
+        "ansible_rulebook.action.helper.update_action_info"
+    ) as mock_update:
+        helper.update_action_state(info)
+
+        mock_update.assert_called_once_with(
+            "rs1", "matching-uuid-123", 0, info
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_action_state_without_persistent_info(metadata, control):
+    """Test update_action_state doesn't call update_action_info when no
+    persistent_info"""
+    helper = Helper(metadata, control, "test_action")
+
+    info = {"status": "completed"}
+
+    with patch(
+        "ansible_rulebook.action.helper.update_action_info"
+    ) as mock_update:
+        helper.update_action_state(info)
+
+        mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_event_uuid_label_single_event(metadata):
+    """Test get_event_uuid_label with single event"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"event": {"meta": {"uuid": EVENT_UUID}}},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    label = helper.get_event_uuid_label()
+
+    assert label == f"eda-event-uuid-{EVENT_UUID}"
+
+
+@pytest.mark.asyncio
+async def test_get_event_uuid_label_multiple_events(metadata):
+    """Test get_event_uuid_label with multiple events (uses first event)"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"events": {"m_0": {"meta": {"uuid": EVENT_UUID}}}},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    label = helper.get_event_uuid_label()
+
+    assert label == f"eda-event-uuid-{EVENT_UUID}"
+
+
+@pytest.mark.asyncio
+async def test_get_event_uuid_label_invalid_event(metadata):
+    """Test get_event_uuid_label raises ValueError for invalid event"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"other": "data"},
+        project_data_file="",
+    )
+
+    helper = Helper(metadata, control, "test_action")
+
+    with pytest.raises(ValueError, match="Invalid event type"):
+        helper.get_event_uuid_label()
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_no_persistent_info(metadata, control):
+    """Test get_old_job_url returns None when no persistent_info"""
+    helper = Helper(metadata, control, "test_action")
+
+    result = await helper.get_old_job_url(
+        "test-job", "test-org", "job_template", False
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_no_a_priori(metadata, control):
+    """Test get_old_job_url returns None when no a_priori data"""
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+    persistent_info.a_priori = None
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    result = await helper.get_old_job_url(
+        "test-job", "test-org", "job_template", False
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_with_job_url(metadata, control):
+    """Test get_old_job_url returns job_url from a_priori"""
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+    persistent_info.a_priori = {"job_url": "https://example.com/job/123"}
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    result = await helper.get_old_job_url(
+        "test-job", "test-org", "job_template", False
+    )
+
+    assert result == "https://example.com/job/123"
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_started_status_with_label(metadata):
+    """Test get_old_job_url fetches job_url using label when status is
+    started"""
+    queue = asyncio.Queue()
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"event": {"meta": {"uuid": EVENT_UUID}}},
+        project_data_file="",
+    )
+
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+    persistent_info.a_priori = {"status": STARTED_STATUS}
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    with patch(
+        "ansible_rulebook.action.helper.job_template_runner."
+        "get_job_url_from_label",
+        new_callable=AsyncMock,
+    ) as mock_get_url:
+        mock_get_url.return_value = "https://example.com/job/456"
+
+        result = await helper.get_old_job_url(
+            "test-job", "test-org", "job_template", add_event_uuid_label=True
+        )
+
+        mock_get_url.assert_called_once_with(
+            "test-job",
+            "test-org",
+            "job_template",
+            f"eda-event-uuid-{EVENT_UUID}",
+        )
+        assert result == "https://example.com/job/456"
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_started_status_without_label(metadata, control):
+    """Test get_old_job_url returns None when status is started but no
+    label requested"""
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+    persistent_info.a_priori = {"status": STARTED_STATUS}
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    result = await helper.get_old_job_url(
+        "test-job", "test-org", "job_template", add_event_uuid_label=False
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_old_job_url_failed_status(metadata, control):
+    """Test get_old_job_url returns None when status is failed"""
+    persistent_info = MagicMock()
+    persistent_info.matching_uuid = "matching-uuid-123"
+    persistent_info.action_index = 0
+    persistent_info.a_priori = {"status": FAILED_STATUS}
+
+    metadata_with_persistence = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid=RULE_UUID,
+        rule_set_uuid=RULE_SET_UUID,
+        rule_run_at=RULE_RUN_AT,
+        persistent_info=persistent_info,
+    )
+
+    helper = Helper(metadata_with_persistence, control, "test_action")
+
+    result = await helper.get_old_job_url(
+        "test-job", "test-org", "job_template", add_event_uuid_label=True
+    )
+
+    assert result is None

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -296,3 +296,55 @@ async def test_run_job_template_retries():
                 drools_mock.assert_called_once()
 
             _validate(queue, True)
+
+
+@pytest.mark.asyncio
+async def test_run_job_template_with_null_labels():
+    """Verify labels: null in rulebook YAML does not raise TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": 0,
+        "retry": True,
+        "delay": 0,
+        "set_facts": True,
+        "labels": None,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_job_template."
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_job_template.lang.assert_fact"
+            ):
+                await RunJobTemplate(metadata, control, **action_args)()
+
+        _validate(queue, True)

--- a/tests/unit/action/test_run_job_template.py
+++ b/tests/unit/action/test_run_job_template.py
@@ -102,7 +102,7 @@ async def test_run_job_template_exception(err_msg, err):
     }
     with patch(
         "ansible_rulebook.action.run_job_template."
-        "job_template_runner.run_job_template",
+        "job_template_runner.launch_job_template",
         side_effect=err,
     ):
         await RunJobTemplate(metadata, control, **action_args)()
@@ -156,18 +156,23 @@ async def test_run_job_template(drools_call, additional_args, capsys):
     }
     with patch(
         "ansible_rulebook.action.run_job_template."
-        "job_template_runner.run_job_template",
-        return_value=controller_job,
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
     ):
-        with patch(drools_call) as drools_mock:
-            old_setting = settings.print_events
-            settings.print_events = True
-            try:
-                await RunJobTemplate(metadata, control, **action_args)()
-            finally:
-                settings.print_events = old_setting
-            captured = capsys.readouterr()
-            drools_mock.assert_called_once()
+        with patch(
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(drools_call) as drools_mock:
+                old_setting = settings.print_events
+                settings.print_events = True
+                try:
+                    await RunJobTemplate(metadata, control, **action_args)()
+                finally:
+                    settings.print_events = old_setting
+                captured = capsys.readouterr()
+                drools_mock.assert_called_once()
 
         _validate(queue, True)
         assert terminal.Display.get_banners("job: set-facts", captured.out)
@@ -215,16 +220,21 @@ async def test_run_job_template_url(job_id):
 
     with patch(
         "ansible_rulebook.action.run_job_template."
-        "job_template_runner.run_job_template",
-        return_value=controller_job,
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
     ):
-        await RunJobTemplate(metadata, control, **action_args)()
+        with patch(
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            await RunJobTemplate(metadata, control, **action_args)()
 
-        action = _validate(queue, True)
+            action = _validate(queue, True)
 
-        assert ((not job_id) and (action["url"] == "")) or (
-            job_id and (action["url"] != "")
-        )
+            assert ((not job_id) and (action["url"] == "")) or (
+                job_id and (action["url"] != "")
+            )
 
 
 @pytest.mark.asyncio
@@ -271,13 +281,18 @@ async def test_run_job_template_retries():
 
     with patch(
         "ansible_rulebook.action.run_job_template."
-        "job_template_runner.run_job_template",
-        side_effect=controller_job,
+        "job_template_runner.launch_job_template",
+        return_value="https://www.example.com",
     ):
         with patch(
-            "ansible_rulebook.action.run_job_template.lang.assert_fact"
-        ) as drools_mock:
-            await RunJobTemplate(metadata, control, **action_args)()
-            drools_mock.assert_called_once()
+            "ansible_rulebook.action.run_job_template."
+            "job_template_runner.monitor_job",
+            side_effect=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_job_template.lang.assert_fact"
+            ) as drools_mock:
+                await RunJobTemplate(metadata, control, **action_args)()
+                drools_mock.assert_called_once()
 
-        _validate(queue, True)
+            _validate(queue, True)

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -308,3 +308,58 @@ async def test_run_workflow_template_url(job_id):
             assert ((not job_id) and (action["url"] == "")) or (
                 job_id and (action["url"] != "")
             )
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_template_with_null_labels():
+    """Verify labels: null in rulebook YAML does not raise TypeError."""
+    queue = asyncio.Queue()
+    metadata = Metadata(
+        rule="r1",
+        rule_set="rs1",
+        rule_uuid="u1",
+        rule_set_uuid="u2",
+        rule_run_at="abc",
+    )
+    control = Control(
+        queue=queue,
+        inventory="abc",
+        hosts=["all"],
+        variables={"a": 1},
+        project_data_file="",
+    )
+    action_args = {
+        "name": "fred",
+        "organization": "Default",
+        "retries": 0,
+        "retry": True,
+        "delay": 0,
+        "set_facts": True,
+        "labels": None,
+    }
+    controller_job = {
+        "status": "successful",
+        "rc": 0,
+        "artifacts": dict(b=1),
+        "created": "abc",
+        "id": 10,
+    }
+    with patch(
+        "ansible_rulebook.action.run_workflow_template."
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
+    ):
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_workflow_template."
+                "lang.assert_fact"
+            ):
+                await RunWorkflowTemplate(
+                    metadata, control, **action_args
+                )()
+
+        _validate(queue, True)

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -358,8 +358,6 @@ async def test_run_workflow_template_with_null_labels():
                 "ansible_rulebook.action.run_workflow_template."
                 "lang.assert_fact"
             ):
-                await RunWorkflowTemplate(
-                    metadata, control, **action_args
-                )()
+                await RunWorkflowTemplate(metadata, control, **action_args)()
 
         _validate(queue, True)

--- a/tests/unit/action/test_run_workflow_template.py
+++ b/tests/unit/action/test_run_workflow_template.py
@@ -104,11 +104,16 @@ async def test_run_workflow_template_exception(err_msg, err):
     }
     with patch(
         "ansible_rulebook.action.run_workflow_template."
-        "job_template_runner.run_workflow_job_template",
+        "job_template_runner.launch_workflow_job_template",
         side_effect=err,
     ):
-        await RunWorkflowTemplate(metadata, control, **action_args)()
-        _validate(queue, False, {"error": err_msg})
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            side_effect=err,
+        ):
+            await RunWorkflowTemplate(metadata, control, **action_args)()
+            _validate(queue, False, {"error": err_msg})
 
 
 DROOLS_CALLS = [
@@ -158,18 +163,25 @@ async def test_run_workflow_template(drools_call, additional_args, capsys):
     }
     with patch(
         "ansible_rulebook.action.run_workflow_template."
-        "job_template_runner.run_workflow_job_template",
-        return_value=controller_job,
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
     ):
-        with patch(drools_call) as drools_mock:
-            old_setting = settings.print_events
-            settings.print_events = True
-            try:
-                await RunWorkflowTemplate(metadata, control, **action_args)()
-            finally:
-                settings.print_events = old_setting
-            captured = capsys.readouterr()
-            drools_mock.assert_called_once()
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            with patch(drools_call) as drools_mock:
+                old_setting = settings.print_events
+                settings.print_events = True
+                try:
+                    await RunWorkflowTemplate(
+                        metadata, control, **action_args
+                    )()
+                finally:
+                    settings.print_events = old_setting
+                captured = capsys.readouterr()
+                drools_mock.assert_called_once()
 
         _validate(queue, True)
         assert terminal.Display.get_banners(
@@ -221,16 +233,22 @@ async def test_run_workflow_template_retries():
 
     with patch(
         "ansible_rulebook.action.run_workflow_template."
-        "job_template_runner.run_workflow_job_template",
-        side_effect=controller_job,
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
     ):
         with patch(
-            "ansible_rulebook.action.run_workflow_template.lang.assert_fact"
-        ) as drools_mock:
-            await RunWorkflowTemplate(metadata, control, **action_args)()
-            drools_mock.assert_called_once()
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            side_effect=controller_job,
+        ):
+            with patch(
+                "ansible_rulebook.action.run_workflow_template."
+                "lang.assert_fact"
+            ) as drools_mock:
+                await RunWorkflowTemplate(metadata, control, **action_args)()
+                drools_mock.assert_called_once()
 
-        _validate(queue, True)
+            _validate(queue, True)
 
 
 URL_PARAMETERS = [
@@ -275,13 +293,18 @@ async def test_run_workflow_template_url(job_id):
 
     with patch(
         "ansible_rulebook.action.run_workflow_template."
-        "job_template_runner.run_workflow_job_template",
-        return_value=controller_job,
+        "job_template_runner.launch_workflow_job_template",
+        return_value="https://www.example.com",
     ):
-        await RunWorkflowTemplate(metadata, control, **action_args)()
+        with patch(
+            "ansible_rulebook.action.run_workflow_template."
+            "job_template_runner.monitor_job",
+            return_value=controller_job,
+        ):
+            await RunWorkflowTemplate(metadata, control, **action_args)()
 
-        action = _validate(queue, True)
+            action = _validate(queue, True)
 
-        assert ((not job_id) and (action["url"] == "")) or (
-            job_id and (action["url"] != "")
-        )
+            assert ((not job_id) and (action["url"] == "")) or (
+                job_id and (action["url"] != "")
+            )

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -656,7 +656,9 @@ class TestRunRulesets:
         )
 
         source_queue = asyncio.Queue()
-        ruleset_queues = [RuleSetQueue(mock_ruleset, source_queue)]
+        ruleset_queues = [
+            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+        ]
         variables = {"test": "value"}
 
         # Mock dependencies
@@ -717,12 +719,15 @@ class TestRunRulesets:
         )
 
         source_queue = asyncio.Queue()
-        ruleset_queues = [RuleSetQueue(mock_ruleset, source_queue)]
+        ruleset_queues = [
+            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+        ]
         variables = {}
 
         # Mock parsed_args with heartbeat
         parsed_args = argparse.Namespace()
         parsed_args.heartbeat = 30
+        parsed_args.persistence_id = None
 
         with patch(
             "ansible_rulebook.engine.rule_generator.generate_rulesets"
@@ -786,7 +791,9 @@ class TestRunRulesets:
         )
 
         source_queue = asyncio.Queue()
-        ruleset_queues = [RuleSetQueue(mock_ruleset, source_queue)]
+        ruleset_queues = [
+            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+        ]
         variables = {}
 
         with patch(
@@ -858,7 +865,9 @@ class TestRunRulesets:
         )
 
         source_queue = asyncio.Queue()
-        ruleset_queues = [RuleSetQueue(mock_ruleset, source_queue)]
+        ruleset_queues = [
+            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+        ]
         variables = {}
         inventory = "/path/to/inventory"
 
@@ -925,7 +934,9 @@ class TestRunRulesets:
         )
 
         source_queue = asyncio.Queue()
-        ruleset_queues = [RuleSetQueue(mock_ruleset, source_queue)]
+        ruleset_queues = [
+            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+        ]
         variables = {}
 
         with patch(

--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -1,0 +1,684 @@
+#  Copyright 2023 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for ansible_rulebook.persistence module."""
+
+import argparse
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ansible_rulebook import persistence
+from ansible_rulebook.conf import settings
+
+SSL_PASS = "test_ssl_password"
+TEST_PASSWORD = "test_password"
+
+
+@pytest.fixture
+def mock_lang():
+    """Mock the drools.ruleset module."""
+    with patch("ansible_rulebook.persistence.lang") as mock:
+        yield mock
+
+
+@pytest.fixture
+def postgres_variables():
+    """Return a valid set of PostgreSQL configuration variables."""
+    return {
+        "drools_db_host": "localhost",
+        "drools_db_port": 5432,
+        "drools_db_name": "test_db",
+        "drools_db_user": "test_user",
+        "drools_db_password": TEST_PASSWORD,
+        "drools_sslmode": "require",
+    }
+
+
+@pytest.fixture
+def h2_variables():
+    """Return a valid set of H2 configuration variables."""
+    return {
+        "drools_db_file_path": "/tmp/test_db",
+    }
+
+
+@pytest.fixture
+def parsed_args():
+    """Return mock parsed arguments."""
+    args = argparse.Namespace()
+    args.persistence_id = "test-persistence-id"
+    args.id = "worker-1"
+    return args
+
+
+@pytest.fixture
+def reset_settings():
+    """Reset settings.persistence_enabled after each test."""
+    original_value = settings.persistence_enabled
+    yield
+    settings.persistence_enabled = original_value
+
+
+class TestEnablePersistence:
+    """Tests for enable_persistence function."""
+
+    def test_enable_persistence_with_postgres(
+        self, mock_lang, postgres_variables, parsed_args, reset_settings
+    ):
+        """Test enabling persistence with PostgreSQL configuration."""
+        persistence.enable_persistence(parsed_args, postgres_variables)
+
+        assert settings.persistence_enabled is True
+        mock_lang.initialize_ha.assert_called_once()
+        call_kwargs = mock_lang.initialize_ha.call_args.kwargs
+
+        assert call_kwargs["uuid"] == "test-persistence-id"
+        assert call_kwargs["worker_name"] == "instance-worker-1"
+        assert call_kwargs["db_params"]["db_type"] == "postgres"
+        assert call_kwargs["db_params"]["host"] == "localhost"
+        assert call_kwargs["db_params"]["port"] == 5432
+        assert call_kwargs["db_params"]["database"] == "test_db"
+        assert call_kwargs["db_params"]["user"] == "test_user"
+        assert call_kwargs["db_params"]["password"] == TEST_PASSWORD
+        assert call_kwargs["db_params"]["sslmode"] == "require"
+
+    def test_enable_persistence_with_h2(
+        self, mock_lang, h2_variables, parsed_args, reset_settings
+    ):
+        """Test enabling persistence with H2 configuration."""
+        persistence.enable_persistence(parsed_args, h2_variables)
+
+        assert settings.persistence_enabled is True
+        mock_lang.initialize_ha.assert_called_once()
+        call_kwargs = mock_lang.initialize_ha.call_args.kwargs
+
+        assert call_kwargs["uuid"] == "test-persistence-id"
+        assert call_kwargs["worker_name"] == "instance-worker-1"
+        assert call_kwargs["db_params"]["db_type"] == "h2"
+        assert call_kwargs["db_params"]["db_file_path"] == "/tmp/test_db"
+
+    def test_enable_persistence_no_db_config(
+        self, mock_lang, parsed_args, reset_settings
+    ):
+        """Test persistence not enabled without database config."""
+        variables = {"some_other_key": "value"}
+
+        persistence.enable_persistence(parsed_args, variables)
+
+        assert settings.persistence_enabled is False
+        mock_lang.initialize_ha.assert_not_called()
+
+    def test_enable_persistence_with_encryption_keys(
+        self, mock_lang, postgres_variables, parsed_args, reset_settings
+    ):
+        """Test enabling persistence with encryption keys configured."""
+        postgres_variables["drools_primary_encryption_secret"] = "primary_key"
+        postgres_variables[
+            "drools_secondary_encryption_secret"
+        ] = "secondary_key"
+
+        persistence.enable_persistence(parsed_args, postgres_variables)
+
+        call_kwargs = mock_lang.initialize_ha.call_args.kwargs
+        assert call_kwargs["config"]["encryption_key_primary"] == "primary_key"
+        assert (
+            call_kwargs["config"]["encryption_key_secondary"]
+            == "secondary_key"
+        )
+
+    def test_enable_persistence_with_grace_period(
+        self, mock_lang, postgres_variables, parsed_args, reset_settings
+    ):
+        """Test enabling persistence with expired window grace period."""
+        postgres_variables["drools_expired_window_grace_period"] = "300"
+
+        persistence.enable_persistence(parsed_args, postgres_variables)
+
+        call_kwargs = mock_lang.initialize_ha.call_args.kwargs
+        assert call_kwargs["config"]["expired_window_grace_period"] == 300
+
+    def test_enable_persistence_logs_initialization(
+        self,
+        mock_lang,
+        postgres_variables,
+        parsed_args,
+        reset_settings,
+        caplog,
+    ):
+        """Test that persistence initialization is logged."""
+        import logging
+
+        caplog.set_level(logging.INFO)
+
+        persistence.enable_persistence(parsed_args, postgres_variables)
+
+        assert "Initializing drools HA mode" in caplog.text
+        assert "test-persistence-id" in caplog.text
+        assert "postgres" in caplog.text
+
+
+class TestUpdateActionInfo:
+    """Tests for update_action_info function."""
+
+    def test_update_action_info_create(self, mock_lang, reset_settings):
+        """Test creating new action info."""
+        settings.persistence_enabled = True
+        info = {"status": "running", "job_id": "12345"}
+
+        persistence.update_action_info(
+            "test_ruleset", "uuid-123", 0, info, create=True
+        )
+
+        mock_lang.add_action_info.assert_called_once_with(
+            "test_ruleset", "uuid-123", 0, json.dumps(info)
+        )
+
+    def test_update_action_info_update(self, mock_lang, reset_settings):
+        """Test updating existing action info."""
+        settings.persistence_enabled = True
+        existing_data = {"status": "running", "job_id": "12345"}
+        mock_lang.get_action_info.return_value = json.dumps(existing_data)
+
+        new_info = {"status": "completed", "end_time": "2023-01-01T00:00:00"}
+
+        persistence.update_action_info(
+            "test_ruleset", "uuid-123", 0, new_info, create=False
+        )
+
+        mock_lang.get_action_info.assert_called_once_with(
+            "test_ruleset", "uuid-123", 0
+        )
+
+        expected_data = {
+            "status": "completed",
+            "job_id": "12345",
+            "end_time": "2023-01-01T00:00:00",
+        }
+        mock_lang.update_action_info.assert_called_once_with(
+            "test_ruleset", "uuid-123", 0, json.dumps(expected_data)
+        )
+
+    def test_update_action_info_update_logs_debug(
+        self, mock_lang, reset_settings, caplog
+    ):
+        """Test that debug logging occurs when updating action info."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        settings.persistence_enabled = True
+        existing_data = {"status": "running"}
+        mock_lang.get_action_info.return_value = json.dumps(existing_data)
+
+        new_info = {"status": "completed"}
+
+        persistence.update_action_info(
+            "test_ruleset", "uuid-123", 0, new_info, create=False
+        )
+
+        assert "Updating action info" in caplog.text
+
+    def test_update_action_info_update_with_corrupt_data(
+        self, mock_lang, reset_settings, caplog
+    ):
+        """Test updating action info when existing data is corrupted."""
+        settings.persistence_enabled = True
+        mock_lang.get_action_info.return_value = "invalid json {{"
+
+        new_info = {"status": "completed"}
+
+        persistence.update_action_info(
+            "test_ruleset", "uuid-123", 0, new_info, create=False
+        )
+
+        # Should still update with new info only
+        mock_lang.update_action_info.assert_called_once()
+        call_args = mock_lang.update_action_info.call_args[0]
+        assert json.loads(call_args[3]) == {"status": "completed"}
+
+        # Should log an error
+        assert "Error parsing saved action data" in caplog.text
+
+    def test_update_action_info_persistence_disabled(
+        self, mock_lang, reset_settings
+    ):
+        """Test that nothing happens when persistence is disabled."""
+        settings.persistence_enabled = False
+        info = {"status": "running"}
+
+        persistence.update_action_info(
+            "test_ruleset", "uuid-123", 0, info, create=True
+        )
+
+        mock_lang.add_action_info.assert_not_called()
+        mock_lang.update_action_info.assert_not_called()
+
+
+class TestGetActionAPriori:
+    """Tests for get_action_a_priori function."""
+
+    def test_get_action_a_priori_exists(self, mock_lang):
+        """Test retrieving existing action info."""
+        action_data = {"status": "running", "job_id": "12345"}
+        mock_lang.action_info_exists.return_value = True
+        mock_lang.get_action_info.return_value = json.dumps(action_data)
+
+        result = persistence.get_action_a_priori("test_ruleset", "uuid-123", 0)
+
+        assert result == action_data
+        mock_lang.action_info_exists.assert_called_once_with(
+            "test_ruleset", "uuid-123", 0
+        )
+        mock_lang.get_action_info.assert_called_once_with(
+            "test_ruleset", "uuid-123", 0
+        )
+
+    def test_get_action_a_priori_logs_debug(self, mock_lang, caplog):
+        """Test that debug logging occurs when retrieving action info."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        action_data = {"status": "running"}
+        mock_lang.action_info_exists.return_value = True
+        mock_lang.get_action_info.return_value = json.dumps(action_data)
+
+        persistence.get_action_a_priori("test_ruleset", "uuid-123", 0)
+
+        assert "Previous action data" in caplog.text
+
+    def test_get_action_a_priori_not_exists(self, mock_lang):
+        """Test retrieving non-existent action info."""
+        mock_lang.action_info_exists.return_value = False
+
+        result = persistence.get_action_a_priori("test_ruleset", "uuid-123", 0)
+
+        assert result is None
+        mock_lang.get_action_info.assert_not_called()
+
+    def test_get_action_a_priori_corrupt_data(self, mock_lang, caplog):
+        """Test retrieving corrupted action info."""
+        mock_lang.action_info_exists.return_value = True
+        mock_lang.get_action_info.return_value = "invalid json {{"
+
+        result = persistence.get_action_a_priori("test_ruleset", "uuid-123", 0)
+
+        assert result == {}
+        assert "Error parsing prior action data" in caplog.text
+
+
+class TestEnableLeader:
+    """Tests for enable_leader function."""
+
+    def test_enable_leader_when_persistence_enabled(
+        self, mock_lang, reset_settings
+    ):
+        """Test enabling leader mode when persistence is enabled."""
+        settings.persistence_enabled = True
+
+        persistence.enable_leader()
+
+        mock_lang.enable_leader.assert_called_once()
+
+    def test_enable_leader_when_persistence_disabled(
+        self, mock_lang, reset_settings
+    ):
+        """Test leader mode not enabled when persistence disabled."""
+        settings.persistence_enabled = False
+
+        persistence.enable_leader()
+
+        mock_lang.enable_leader.assert_not_called()
+
+
+class TestGetPostgresParams:
+    """Tests for _get_postgres_params function."""
+
+    def test_get_postgres_params_minimal(self):
+        """Test extracting minimal PostgreSQL parameters."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert result is not None
+        assert result["db_type"] == "postgres"
+        assert result["host"] == "localhost"
+        assert result["port"] == 5432
+        assert result["database"] == "test_db"
+
+    def test_get_postgres_params_with_auth(self):
+        """Test extracting PostgreSQL parameters with authentication."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+            "drools_db_user": "admin",
+            "drools_db_password": "secret",
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert result["user"] == "admin"
+        assert result["password"] == "secret"
+
+    def test_get_postgres_params_with_ssl(self):
+        """Test extracting PostgreSQL parameters with SSL configuration."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+            "drools_sslmode": "require",
+            "drools_sslpassword": SSL_PASS,
+            "drools_sslrootcert": "/path/to/root.crt",
+            "drools_sslkey": "/path/to/key.pem",
+            "drools_sslcert": "/path/to/cert.pem",
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert result["sslmode"] == "require"
+        assert result["sslpassword"] == SSL_PASS
+        assert result["sslrootcert"] == "/path/to/root.crt"
+        assert result["sslkey"] == "/path/to/key.pem"
+        assert result["sslcert"] == "/path/to/cert.pem"
+
+    def test_get_postgres_params_with_eda_filenames(self):
+        """Test extracting PostgreSQL parameters with EDA filename paths."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+            "eda": {
+                "filename": {
+                    "drools_sslrootcert": "/eda/path/root.crt",
+                    "drools_sslkey": "/eda/path/key.pem",
+                    "drools_sslcert": "/eda/path/cert.pem",
+                }
+            },
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert result["sslrootcert"] == "/eda/path/root.crt"
+        assert result["sslkey"] == "/eda/path/key.pem"
+        assert result["sslcert"] == "/eda/path/cert.pem"
+
+    def test_get_postgres_params_missing_required(self):
+        """Test that None is returned when required parameters are missing."""
+        # Missing drools_db_name
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert result is None
+
+    def test_get_postgres_params_empty_variables(self):
+        """Test that None is returned with empty variables."""
+        result = persistence._get_postgres_params({})
+
+        assert result is None
+
+    def test_get_postgres_params_priority_eda_over_direct(self):
+        """Test that EDA filename paths take priority over direct variables."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+            "drools_sslcert": "/direct/path/cert.pem",
+            "eda": {
+                "filename": {
+                    "drools_sslcert": "/eda/path/cert.pem",
+                }
+            },
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        # EDA filename path is processed first in the mappings dict,
+        # but dpath.get will find the direct variable last, so direct wins
+        # since it overwrites in the iteration
+        assert result["sslcert"] == "/direct/path/cert.pem"
+
+    def test_get_postgres_params_skips_falsy_values(self):
+        """Test that falsy values (empty string, None) are not added."""
+        variables = {
+            "drools_db_host": "localhost",
+            "drools_db_port": 5432,
+            "drools_db_name": "test_db",
+            "drools_db_user": "",  # Empty string should be skipped
+            "drools_db_password": None,  # None should be skipped
+        }
+
+        result = persistence._get_postgres_params(variables)
+
+        assert "user" not in result
+        assert "password" not in result
+
+
+class TestGetH2Params:
+    """Tests for _get_h2_params function."""
+
+    def test_get_h2_params_valid(self):
+        """Test extracting H2 parameters with valid configuration."""
+        variables = {
+            "drools_db_file_path": "/tmp/test_db",
+        }
+
+        result = persistence._get_h2_params(variables)
+
+        assert result is not None
+        assert result["db_type"] == "h2"
+        assert result["db_file_path"] == "/tmp/test_db"
+
+    def test_get_h2_params_missing_required(self):
+        """Test that None is returned when required parameters are missing."""
+        variables = {
+            "some_other_key": "value",
+        }
+
+        result = persistence._get_h2_params(variables)
+
+        assert result is None
+
+    def test_get_h2_params_empty_variables(self):
+        """Test that None is returned with empty variables."""
+        result = persistence._get_h2_params({})
+
+        assert result is None
+
+
+class TestGetConfigParams:
+    """Tests for _get_config_params function."""
+
+    def test_get_config_params_defaults(self):
+        """Test extracting config parameters with default values."""
+        variables = {}
+
+        result = persistence._get_config_params(variables)
+
+        assert "encryption_key_primary" not in result
+        assert "encryption_key_secondary" not in result
+        assert "expired_window_grace_period" not in result
+        assert "overwrite_if_rulebook_changes" not in result
+        assert "dedup_buffer_size" not in result
+
+    def test_get_config_params_with_encryption_keys(self):
+        """Test extracting config parameters with encryption keys."""
+        variables = {
+            "drools_primary_encryption_secret": "primary_key",
+            "drools_secondary_encryption_secret": "secondary_key",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["encryption_key_primary"] == "primary_key"
+        assert result["encryption_key_secondary"] == "secondary_key"
+
+    def test_get_config_params_with_grace_period(self):
+        """Test extracting config parameters with grace period."""
+        variables = {
+            "drools_expired_window_grace_period": "600",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["expired_window_grace_period"] == 600
+
+    def test_get_config_params_all_options(self):
+        """Test extracting all config parameters."""
+        variables = {
+            "drools_primary_encryption_secret": "primary",
+            "drools_secondary_encryption_secret": "secondary",
+            "drools_expired_window_grace_period": "1200",
+            "drools_overwrite_if_rulebook_changes": True,
+            "drools_deduplication_window_size": "1000",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["encryption_key_primary"] == "primary"
+        assert result["encryption_key_secondary"] == "secondary"
+        assert result["expired_window_grace_period"] == 1200
+        assert result["overwrite_if_rulebook_changes"] is True
+        assert result["dedup_buffer_size"] == 1000
+
+    def test_get_config_params_with_overwrite_bool_true(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as bool True.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": True,
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is True
+
+    def test_get_config_params_with_overwrite_bool_false(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as bool False.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": False,
+        }
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is False
+
+    def test_get_config_params_with_overwrite_string_true(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as string 'true'.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": "true",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is True
+
+    def test_get_config_params_with_overwrite_string_false(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as string 'false'.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": "false",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is False
+
+    def test_get_config_params_with_overwrite_string_yes(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as string 'yes'.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": "yes",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is True
+
+    def test_get_config_params_with_overwrite_string_no(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as string 'no'.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": "no",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is False
+
+    def test_get_config_params_with_overwrite_int_1(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as int 1.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": 1,
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is True
+
+    def test_get_config_params_with_overwrite_int_0(self):
+        """Test extracting config with overwrite_if_rulebook_changes.
+
+        Testing as int 0.
+        """
+        variables = {
+            "drools_overwrite_if_rulebook_changes": 0,
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["overwrite_if_rulebook_changes"] is False
+
+    def test_get_config_params_with_dedup_buffer_size(self):
+        """Test extracting config with dedup_buffer_size."""
+        variables = {
+            "drools_deduplication_window_size": "5000",
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["dedup_buffer_size"] == 5000
+
+    def test_get_config_params_with_dedup_buffer_size_int(self):
+        """Test extracting config with dedup_buffer_size as integer."""
+        variables = {
+            "drools_deduplication_window_size": 10000,
+        }
+
+        result = persistence._get_config_params(variables)
+
+        assert result["dedup_buffer_size"] == 10000


### PR DESCRIPTION
New signed commit to replace https://github.com/mkanoor/ansible-rulebook/pull/2

## Problem

In the `event_persistence` branch, both `run_job_template.py` and `run_workflow_template.py` construct `job_labels` like this:

```python
job_labels = list(self.action_args.get("labels", []))
```

When a rulebook specifies `labels: null` (valid YAML — `null`, `~`, or empty value all parse to `None` in Python), `action_args.get("labels", [])` returns `None` because the key **exists** with value `None` — the default `[]` is only used when the key is absent. Then `list(None)` raises:

```
TypeError: 'NoneType' object is not iterable
```

This crashes the action — the job never launches and rule processing halts.

### Prior behavior (main branch)

On `main`, labels were passed straight through as `None`:
```python
self.action_args.get("labels"),  # None passed to runner, handled downstream
```
The downstream `_get_label_ids_from_names` method treats `None` and `[]` identically (both are falsy, so the `if labels:` gate skips user labels). No crash occurred.

### When it shows up in production

Any user with `labels: null` (or `labels: ~`) in their rulebook YAML hits a `TypeError` crash on every rule firing. This is a regression introduced by the persistence changes.

## Solution

Replace `get("labels", [])` with `get("labels") or []` in both files:

```python
job_labels = list(self.action_args.get("labels") or [])
```

The `or []` coerces `None` to `[]` before the `list()` copy, which is consistent with how the downstream controller API treats them — [AWX explicitly documents](https://github.com/ansible/awx/blob/devel/awx/main/models/jobs.py) that *"Many to manys can't distinguish between None and []. We assume [] is none."*

## Files changed

- `ansible_rulebook/action/run_job_template.py` — line 93
- `ansible_rulebook/action/run_workflow_template.py` — line 92