### PR TITLE
fix: resolve feedback deadlock, test type mismatch, and inconsistent null check

### DIFF
--- a/ansible_rulebook/action/run_workflow_template.py
+++ b/ansible_rulebook/action/run_workflow_template.py
@@ -111,7 +111,7 @@ class RunWorkflowTemplate:
                         retries,
                     )
                 # Launch the workflow and get URL immediately
-                if job_url is None:
+                if not job_url:
                     job_url = (
                         await job_template_runner.launch_workflow_job_template(
                             self.name,

--- a/ansible_rulebook/rule_set_runner.py
+++ b/ansible_rulebook/rule_set_runner.py
@@ -252,6 +252,12 @@ class RuleSetRunner:
                     await self.event_log.put(dict(type="EmptyEvent"))
                     continue
 
+                # Feedback must be sent for any event the engine
+                # received, even if already observed or unhandled,
+                # so the source can advance. Without this, feedback-
+                # enabled sources deadlock waiting for a response
+                # that never arrives.
+                send_feedback = False
                 try:
                     logger.debug(
                         "Posting data to ruleset %s => %s",
@@ -259,30 +265,18 @@ class RuleSetRunner:
                         str(data),
                     )
                     lang.post(self.name, data)
-
-                    try:
-                        source_name = dpath.get(data, "meta/source/name")
-                    except KeyError:
-                        source_name = None
-
-                    if (
-                        source_name
-                        and source_name
-                        in self.ruleset_queue_plan.source_feedback_queues
-                    ):
-                        feedback_queue = (
-                            self.ruleset_queue_plan.source_feedback_queues.get(
-                                source_name
-                            )
-                        )
-                        await feedback_queue.put(data)
+                    send_feedback = True
                 except asyncio.CancelledError:
                     raise
                 except MessageObservedException:
                     logger.debug("MessageObservedException: %s", data)
+                    send_feedback = True
                 except MessageNotHandledException:
                     logger.debug("MessageNotHandledException: %s", data)
+                    send_feedback = True
                 except BaseException as e:
+                    # On unexpected errors skip feedback; the event
+                    # state is unknown.
                     logger.error(e)
                 finally:
                     logger.debug(lang.get_pending_events(self.name))
@@ -296,6 +290,30 @@ class RuleSetRunner:
                         self.event_counter += 1
                     while self.ruleset_queue_plan.plan.queue.qsize() > 10:
                         await asyncio.sleep(0)
+
+                # Send feedback outside the try/except so it runs
+                # regardless of which lang.post() outcome occurred.
+                if send_feedback:
+                    try:
+                        source_name = dpath.get(
+                            data, "meta/source/name"
+                        )
+                    except KeyError:
+                        source_name = None
+
+                    if (
+                        source_name
+                        and source_name
+                        in self.ruleset_queue_plan
+                        .source_feedback_queues
+                    ):
+                        feedback_queue = (
+                            self.ruleset_queue_plan
+                            .source_feedback_queues.get(
+                                source_name
+                            )
+                        )
+                        await feedback_queue.put(data)
         except asyncio.CancelledError:
             logger.debug("Source Task Cancelled for ruleset %s", self.name)
             raise

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -55,7 +55,7 @@ async def test_generate_rules():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), {}) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -80,7 +80,7 @@ async def test_generate_rules_multiple_conditions_any():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), {}) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -108,7 +108,7 @@ async def test_generate_rules_multiple_conditions_all():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), {}) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -134,7 +134,7 @@ async def test_generate_rules_multiple_conditions_all_3():
 
     rulesets = parse_rule_sets(data)
     print(rulesets)
-    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), {}) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
 
     durable_rulesets[0].plan.queue = asyncio.Queue()
@@ -234,7 +234,7 @@ async def test_rule_name_substitution():
         inventory = yaml.safe_load(f.read())
 
     rulesets = parse_rule_sets(data, variables)
-    ruleset_queues = [(ruleset, Queue(), Queue()) for ruleset in rulesets]
+    ruleset_queues = [(ruleset, Queue(), {}) for ruleset in rulesets]
     durable_rulesets = generate_rulesets(ruleset_queues, dict(), inventory)
     ruleset_name = durable_rulesets[0].ruleset.name
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -657,7 +657,7 @@ class TestRunRulesets:
 
         source_queue = asyncio.Queue()
         ruleset_queues = [
-            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+            RuleSetQueue(mock_ruleset, source_queue, {})
         ]
         variables = {"test": "value"}
 
@@ -720,7 +720,7 @@ class TestRunRulesets:
 
         source_queue = asyncio.Queue()
         ruleset_queues = [
-            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+            RuleSetQueue(mock_ruleset, source_queue, {})
         ]
         variables = {}
 
@@ -792,7 +792,7 @@ class TestRunRulesets:
 
         source_queue = asyncio.Queue()
         ruleset_queues = [
-            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+            RuleSetQueue(mock_ruleset, source_queue, {})
         ]
         variables = {}
 
@@ -866,7 +866,7 @@ class TestRunRulesets:
 
         source_queue = asyncio.Queue()
         ruleset_queues = [
-            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+            RuleSetQueue(mock_ruleset, source_queue, {})
         ]
         variables = {}
         inventory = "/path/to/inventory"
@@ -935,7 +935,7 @@ class TestRunRulesets:
 
         source_queue = asyncio.Queue()
         ruleset_queues = [
-            RuleSetQueue(mock_ruleset, source_queue, asyncio.Queue())
+            RuleSetQueue(mock_ruleset, source_queue, {})
         ]
         variables = {}
 


### PR DESCRIPTION
- Fix feedback deadlock in `_drain_source_queue` when `lang.post()` raises
  `MessageObservedException` or `MessageNotHandledException`. Feedback logic
  was inside the `try` block, so any exception skipped sending feedback to
  the source plugin, causing feedback-enabled sources to block forever.
  Moved feedback outside the try/except with a `send_feedback` flag.
- Fix wrong type for `source_feedback_queues` in test `RuleSetQueue`
  instantiations. Tests passed `Queue()` where `dict[str, asyncio.Queue]`
  was expected, which would raise `TypeError` if the feedback code path
  were triggered.
- Use `if not job_url:` in `run_workflow_template.py` to match
  `run_job_template.py` and `helper.py`. The previous `if job_url is None:`
  would not catch an empty string from corrupted persistence data.